### PR TITLE
Fix order of hash_equals args

### DIFF
--- a/src/LINEBot/SignatureValidator.php
+++ b/src/LINEBot/SignatureValidator.php
@@ -34,6 +34,6 @@ class SignatureValidator
         if (empty($signature)) {
             throw new InvalidSignatureException('Signature must not be empty');
         }
-        return hash_equals($signature, base64_encode(hash_hmac('sha256', $json, $channelSecret, true)));
+        return hash_equals(base64_encode(hash_hmac('sha256', $json, $channelSecret, true)), $signature);
     }
 }


### PR DESCRIPTION
See: http://php.net/manual/ja/function.hash-equals.php

PHP.net says
```
It is important to provide the user-supplied string as the second parameter, rather than the first.
```