### PR TITLE
Support Guzzle 6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require": {
     "php": ">=5.4",
-    "guzzlehttp/guzzle": "^5.3"
+    "guzzlehttp/guzzle": "^6.2|^5.3"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8.24",


### PR DESCRIPTION
A lot of packages use the current Guzzle which is API incompatible with version v5.