### PR TITLE
Trim heading whitespaces which are on response header value

### DIFF
--- a/src/LINEBot/HTTPClient/CurlHTTPClient.php
+++ b/src/LINEBot/HTTPClient/CurlHTTPClient.php
@@ -117,7 +117,7 @@ class CurlHTTPClient implements HTTPClient
         foreach (explode("\r\n", $responseHeaderStr) as $responseHeader) {
             $kv = explode(':', $responseHeader, 2);
             if (count($kv) === 2) {
-                $responseHeaders[$kv[0]] = $kv[1];
+                $responseHeaders[$kv[0]] = trim($kv[1]);
             }
         }
 


### PR DESCRIPTION
## now

```
'Content-Type' => ' application/json;charset=UTF-8'
```

## tobe

```
'Content-Type' => 'application/json;charset=UTF-8',
```