### PR TITLE
Fix the handling to specify endpoint base URI

### DIFF
--- a/src/LINEBot.php
+++ b/src/LINEBot.php
@@ -51,8 +51,11 @@ class LINEBot
     {
         $this->httpClient = $httpClient;
         $this->channelSecret = $args['channelSecret'];
-        $this->endpointBase =
-            array_key_exists('endpointBase', $args) && $args['endpointBase'] ?: LINEBot::DEFAULT_ENDPOINT_BASE;
+
+        $this->endpointBase = LINEBot::DEFAULT_ENDPOINT_BASE;
+        if (array_key_exists('endpointBase', $args) && !empty($args['endpointBase'])) {
+            $this->endpointBase = $args['endpointBase'];
+        }
     }
 
     /**


### PR DESCRIPTION
```
$this->endpointBase = array_key_exists('endpointBase', $args) && $args['endpointBase'] ?: LINEBot::DEFAULT_ENDPOINT_BASE;
```

The above code is left-associative. So if `$args['endpointBase']` exists, `$this->endpointBase` will be `1` as true value.

This patch fix that problem.