### PR TITLE
Add method to get event source ID to JoinEvent and LeaveEvent

### DIFF
--- a/src/LINEBot/Event/BaseEvent.php
+++ b/src/LINEBot/Event/BaseEvent.php
@@ -150,4 +150,29 @@ class BaseEvent
             ? $this->event['source']['roomId']
             : null;
     }
+
+    /**
+     * Returns the identifier of the event source that associated with event source type
+     * (i.e. userId, groupId or roomId).
+     *
+     * @return null|string
+     *
+     * @throws InvalidEventSourceException Raise when event source type is invalid
+     */
+    public function getEventSourceId()
+    {
+        if ($this->isUserEvent()) {
+            return $this->getUserId();
+        }
+
+        if ($this->isGroupEvent()) {
+            return $this->getGroupId();
+        }
+
+        if ($this->isRoomEvent()) {
+            return $this->getRoomId();
+        }
+
+        throw new InvalidEventSourceException('Invalid event source type, neither `user`, `room` nor `group`');
+    }
 }

--- a/tests/LINEBot/EventRequestParserTest.php
+++ b/tests/LINEBot/EventRequestParserTest.php
@@ -200,6 +200,7 @@ JSON;
             $this->assertEquals(12345678901234, $event->getTimestamp());
             $this->assertTrue($event->isUserEvent());
             $this->assertEquals('userid', $event->getUserId());
+            $this->assertEquals('userid', $event->getEventSourceId());
             $this->assertInstanceOf('LINE\LINEBot\Event\MessageEvent', $event);
             $this->assertInstanceOf('LINE\LINEBot\Event\MessageEvent\TextMessage', $event);
             /** @var TextMessage $event */
@@ -213,6 +214,7 @@ JSON;
             $event = $events[1];
             $this->assertTrue($event->isGroupEvent());
             $this->assertEquals('groupid', $event->getGroupId());
+            $this->assertEquals('groupid', $event->getEventSourceId());
             $this->assertInstanceOf('LINE\LINEBot\Event\MessageEvent\ImageMessage', $event);
             /** @var ImageMessage $event */
             $this->assertEquals('replytoken', $event->getReplyToken());
@@ -223,6 +225,7 @@ JSON;
             $event = $events[2];
             $this->assertTrue($event->isRoomEvent());
             $this->assertEquals('roomid', $event->getRoomId());
+            $this->assertEquals('roomid', $event->getEventSourceId());
             $this->assertInstanceOf('LINE\LINEBot\Event\MessageEvent\VideoMessage', $event);
             /** @var VideoMessage $event */
             $this->assertEquals('replytoken', $event->getReplyToken());


### PR DESCRIPTION
Now, user must check the event is whether `user` or `group` or `event`.  It is redundant for me to write such code everywhere, so created intelligent getter method to do that.
`#getEventSourceId()` returns the identifier of the event source that associated with event source type (i.e. userId, groupId or roomId).