### PR TITLE
Fix undefined index error

### DIFF
--- a/src/LINEBot/Event/Parser/EventRequestParser.php
+++ b/src/LINEBot/Event/Parser/EventRequestParser.php
@@ -98,10 +98,10 @@ class EventRequestParser
     private static function parseMessageEvent($eventData)
     {
         $messageType = $eventData['message']['type'];
-        $messageClass = self::$messageType2class[$messageType];
-        if (!isset($messageClass)) {
+        if (!array_key_exists($messageType, self::$messageType2class)) {
             throw new UnknownMessageTypeException('Unknown message type has come: ' . $messageType);
         }
+        $messageClass = self::$messageType2class[$messageType];
         return new $messageClass($eventData);
     }
 }

--- a/src/LINEBot/Event/Parser/EventRequestParser.php
+++ b/src/LINEBot/Event/Parser/EventRequestParser.php
@@ -74,10 +74,10 @@ class EventRequestParser
 
         foreach ($parsedReq['events'] as $eventData) {
             $eventType = $eventData['type'];
-            $eventClass = self::$eventType2class[$eventType];
-            if (!isset($eventClass)) {
+            if (!array_key_exists($eventType, self::$eventType2class)) {
                 throw new UnknownEventTypeException('Unknown event type has come: ' . $eventType);
             }
+            $eventClass = self::$eventType2class[$eventType];
 
             if ($eventType === 'message') {
                 $events[] = self::parseMessageEvent($eventData);

--- a/tests/LINEBot/EventRequestParserTest.php
+++ b/tests/LINEBot/EventRequestParserTest.php
@@ -31,8 +31,6 @@ use LINE\LINEBot\Event\MessageEvent\TextMessage;
 use LINE\LINEBot\Event\MessageEvent\VideoMessage;
 use LINE\LINEBot\Event\PostbackEvent;
 use LINE\LINEBot\Event\UnfollowEvent;
-use LINE\LINEBot\Exception\UnknownEventTypeException;
-use LINE\LINEBot\Exception\UnknownMessageTypeException;
 use LINE\Tests\LINEBot\Util\DummyHttpClient;
 
 class EventRequestParserTest extends \PHPUnit_Framework_TestCase
@@ -361,7 +359,7 @@ JSON;
 
     public function testParseUnknownMessageTypeFailure()
     {
-      $this->setExpectedException(UnknownMessageTypeException::class);
+      $this->setExpectedException('LINE\LINEBot\Exception\UnknownMessageTypeException');
 
       $bot = new LINEBot(new DummyHttpClient($this, function () {
       }), ['channelSecret' => 'testsecret']);
@@ -370,7 +368,7 @@ JSON;
 
     public function testParseUnknownEventTypeFailure()
     {
-      $this->setExpectedException(UnknownEventTypeException::class);
+      $this->setExpectedException('LINE\LINEBot\Exception\UnknownEventTypeException');
 
       $bot = new LINEBot(new DummyHttpClient($this, function () {
       }), ['channelSecret' => 'testsecret']);

--- a/tests/LINEBot/EventRequestParserTest.php
+++ b/tests/LINEBot/EventRequestParserTest.php
@@ -31,6 +31,7 @@ use LINE\LINEBot\Event\MessageEvent\TextMessage;
 use LINE\LINEBot\Event\MessageEvent\VideoMessage;
 use LINE\LINEBot\Event\PostbackEvent;
 use LINE\LINEBot\Event\UnfollowEvent;
+use LINE\LINEBot\Exception\UnknownEventTypeException;
 use LINE\LINEBot\Exception\UnknownMessageTypeException;
 use LINE\Tests\LINEBot\Util\DummyHttpClient;
 
@@ -208,6 +209,22 @@ private static $unknownMessageJson = <<<JSON
 }
 JSON;
 
+private static $unknownEventJson = <<<JSON
+{
+ "events":[
+  {
+   "type":"unknown",
+   "timestamp":12345678901234,
+   "source":{
+    "type":"user",
+    "userId":"userid"
+   },
+   "replyToken":"replytoken"
+  }
+ ]
+}
+JSON;
+
     public function testParseEventRequest()
     {
         $bot = new LINEBot(new DummyHttpClient($this, function () {
@@ -349,5 +366,14 @@ JSON;
       $bot = new LINEBot(new DummyHttpClient($this, function () {
       }), ['channelSecret' => 'testsecret']);
       $events = $bot->parseEventRequest($this::$unknownMessageJson, 'jEd5SjALGCDAVyLDXCiXRNzSFQOsbtfwW6AlfbE8P6M=');
+    }
+
+    public function testParseUnknownEventTypeFailure()
+    {
+      $this->setExpectedException(UnknownEventTypeException::class);
+
+      $bot = new LINEBot(new DummyHttpClient($this, function () {
+      }), ['channelSecret' => 'testsecret']);
+      $events = $bot->parseEventRequest($this::$unknownEventJson, 'Eiy4oXXXIQZAY7BKO7jMv/xUhN3d6C8tCftJweoBPJY=');
     }
 }

--- a/tests/LINEBot/EventRequestParserTest.php
+++ b/tests/LINEBot/EventRequestParserTest.php
@@ -31,6 +31,7 @@ use LINE\LINEBot\Event\MessageEvent\TextMessage;
 use LINE\LINEBot\Event\MessageEvent\VideoMessage;
 use LINE\LINEBot\Event\PostbackEvent;
 use LINE\LINEBot\Event\UnfollowEvent;
+use LINE\LINEBot\Exception\UnknownMessageTypeException;
 use LINE\Tests\LINEBot\Util\DummyHttpClient;
 
 class EventRequestParserTest extends \PHPUnit_Framework_TestCase
@@ -187,6 +188,26 @@ class EventRequestParserTest extends \PHPUnit_Framework_TestCase
 }
 JSON;
 
+private static $unknownMessageJson = <<<JSON
+{
+ "events":[
+  {
+   "type":"message",
+   "timestamp":12345678901234,
+   "source":{
+    "type":"user",
+    "userId":"userid"
+   },
+   "replyToken":"replytoken",
+   "message":{
+    "id":"contentid",
+    "type":"unknown"
+   }
+  }
+ ]
+}
+JSON;
+
     public function testParseEventRequest()
     {
         $bot = new LINEBot(new DummyHttpClient($this, function () {
@@ -319,5 +340,14 @@ JSON;
             $this->assertEquals('enter', $event->getBeaconEventType());
             $this->assertEquals("\x12\x34\x56\x78\x90\xab\xcd\xef", $event->getDeviceMessage());
         }
+    }
+
+    public function testParseUnknownMessageTypeFailure()
+    {
+      $this->setExpectedException(UnknownMessageTypeException::class);
+
+      $bot = new LINEBot(new DummyHttpClient($this, function () {
+      }), ['channelSecret' => 'testsecret']);
+      $events = $bot->parseEventRequest($this::$unknownMessageJson, 'jEd5SjALGCDAVyLDXCiXRNzSFQOsbtfwW6AlfbE8P6M=');
     }
 }


### PR DESCRIPTION
When I use webhook api, some one send "file" type message...
I got error, not expected exception.

```php
$arr = ['foo' => 'boo'];
$error = $arr['nothing'];
```

I try same code in php version `5.6.11` and `7.1.1`, both happen
`PHP error:  Undefined index: nothing`