### PR TITLE
Fix apigen

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,40 +1,37 @@
 Hacking guide for SDK developers
 ==
 
-How to run tests
+Testing
 --
 
-Use `make test`.
+Run `make` or `make check` to check comprehensively. Following tests will run.
 
-How to execute [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)
---
-
-Use `make phpcs`.
-
-How to execute [PHPMD](https://phpmd.org/)
---
-
-Use `make phpmd`.
-
-How to execute them all
---
-
-`make`
-
-How to generate HTML phpdoc
---
-
-Use `make doc`
+- [PHPUnit](https://github.com/sebastianbergmann/phpunit) `make test`
+- Copyright check `make copyright`
+- [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) `make phpcs`
+- [PHPMD](https://phpmd.org/) `make phpmd`
 
 Pull request policy
 --
 
 - Please *DON'T* include the generated HTML phpdoc in pull request
 
+Installing [apigen](https://github.com/apigen/apigen)
+--
+
+We use `apigen` to generate API documents automatically. Required packages are not installed by composer because it requires PHP 7.1+.
+
+```
+$ composer require apigen/apigen:dev-master roave/better-reflection:dev-master
+```
+
 Release Flow
 --
 
-1. Generate HTML phpdoc
+Install `apigen` before releasing new version.
+
+1. Update VERSION constant varialbe at `Constant/Meta.php`
+1. Generate HTML phpdoc `make doc`
 1. Make a git tag (this project uses [semantic versioning](http://semver.org/))
 1. Push the tag to origin
 1. Edit [GitHub releases](https://github.com/line/line-bot-sdk-php/releases)
@@ -49,11 +46,3 @@ e.g.
 $ make release VERSION=1.2.3
 # Then, edit GitHub releases
 ```
-
-Testing of HTTP client
---
-
-Test cases of HTTP client send HTTP request actually to [req_mirror](https://github.com/moznion/req_mirror). req_miror is an HTTP server that parrots received a request as a response.
-`make install-devtool` downloads an executable binary of req_mirror to your `devtool/` directory and test runner launches req_mirror server at `beforeClass` phase.
-After, each test case sends request to the launched server and verify the request.
-

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,13 @@
     "phpunit/phpunit": "^4.8.24||^5||^6",
     "phpmd/phpmd": "~2.4",
     "squizlabs/php_codesniffer": "~2.6||^3",
-    "apigen/apigen": "dev-master",
-    "roave/better-reflection": "dev-master",
-    "indigophp/hash-compat": "~1.1.0"
+    "indigophp/hash-compat": "~1.1.0",
+    "symfony/config": "^3.3",
+    "symfony/dependency-injection": "^3.3"
+  },
+  "suggest": {
+    "apigen/apigen": "Install with roave/better-reflection:dev-master to generate docs",
+    "roave/better-reflection": "Required by apigen/apigen:dev-master"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "phpunit/phpunit": "^4.8.24||^5||^6",
     "phpmd/phpmd": "~2.4",
     "squizlabs/php_codesniffer": "~2.6",
-    "apigen/apigen": "~4.1",
+    "apigen/apigen": "dev-master",
+    "roave/better-reflection": "dev-master",
     "indigophp/hash-compat": "~1.1.0"
   },
   "autoload": {
@@ -41,7 +42,7 @@
   },
   "scripts": {
     "test": "phpunit --debug tests",
-    "doc": "apigen generate --source=src --destination=docs --title line-bot-sdk-php",
+    "doc": "apigen generate src --destination docs",
     "cs": "phpcs --standard=PSR2 src tests examples/EchoBot/src examples/EchoBot/public examples/KitchenSink/src examples/KitchenSink/public",
     "md": "phpmd --ignore-violations-on-exit src,examples/EchoBot/src,examples/EchoBot/public,examples/KitchenSink/src,examples/KitchenSink/public text phpmd.xml"
   }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "require-dev": {
     "phpunit/phpunit": "^4.8.24||^5||^6",
     "phpmd/phpmd": "~2.4",
-    "squizlabs/php_codesniffer": "~2.6",
+    "squizlabs/php_codesniffer": "~2.6||^3",
     "apigen/apigen": "dev-master",
     "roave/better-reflection": "dev-master",
     "indigophp/hash-compat": "~1.1.0"

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
-<ruleset name="My first PHPMD rule set" xmlns="http://pmd.sf.net/ruleset/1.0.0"
+<ruleset name="line-bot-sdk-php PHPMD rule set" xmlns="http://pmd.sf.net/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
+                http://pmd.sf.net/ruleset_xml_schema.xsd"
          xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
 
     <description>line-bot-sdk-php phpmd custom rules</description>


### PR DESCRIPTION
I have to make apigen work to release new version of this library.
Removed `apigen` dependency from `require-dev` because it supports only PHP 7.1+

If you need to generate docs, install apigen manually like this:
`composer require apigen/apigen:dev-master roave/better-reflection:dev-master`

Fixes: #131 

This p-r also includes minor library updates:
 - Supported codesniffer version 3.x
 - Changed phpmd config name