### PR TITLE
Support new options for template message image

### DIFF
--- a/src/LINEBot/MessageBuilder/TemplateBuilder/ButtonTemplateBuilder.php
+++ b/src/LINEBot/MessageBuilder/TemplateBuilder/ButtonTemplateBuilder.php
@@ -35,6 +35,12 @@ class ButtonTemplateBuilder implements TemplateBuilder
     private $text;
     /** @var string */
     private $thumbnailImageUrl;
+    /** @var string */
+    private $imageAspectRatio;
+    /** @var string */
+    private $imageSize;
+    /** @var string */
+    private $imageBackgroundColor;
     /** @var TemplateActionBuilder[] */
     private $actionBuilders;
 
@@ -42,19 +48,25 @@ class ButtonTemplateBuilder implements TemplateBuilder
     private $template;
 
     /**
-     * ConfirmTemplate constructor.
+     * ButtonTemplateBuilder constructor.
      *
      * @param string $title
      * @param string $text
      * @param string $thumbnailImageUrl
      * @param TemplateActionBuilder[] $actionBuilders
+     * @param string|null $imageAspectRatio
+     * @param string|null $imageSize
+     * @param string|null $imageBackgroundColor
      */
-    public function __construct($title, $text, $thumbnailImageUrl, array $actionBuilders)
+    public function __construct($title, $text, $thumbnailImageUrl, array $actionBuilders, $imageAspectRatio = null, $imageSize = null, $imageBackgroundColor = null)
     {
         $this->title = $title;
         $this->text = $text;
         $this->thumbnailImageUrl = $thumbnailImageUrl;
         $this->actionBuilders = $actionBuilders;
+        $this->imageAspectRatio = $imageAspectRatio;
+        $this->imageSize = $imageSize;
+        $this->imageBackgroundColor = $imageBackgroundColor;
     }
 
     /**
@@ -80,6 +92,18 @@ class ButtonTemplateBuilder implements TemplateBuilder
             'text' => $this->text,
             'actions' => $actions,
         ];
+
+        if ($this->imageAspectRatio) {
+            $this->template['imageAspectRatio'] = $this->imageAspectRatio;
+        }
+
+        if ($this->imageSize) {
+            $this->template['imageSize'] = $this->imageSize;
+        }
+
+        if ($this->imageBackgroundColor) {
+            $this->template['imageBackgroundColor'] = $this->imageBackgroundColor;
+        }
 
         return $this->template;
     }

--- a/src/LINEBot/MessageBuilder/TemplateBuilder/ButtonTemplateBuilder.php
+++ b/src/LINEBot/MessageBuilder/TemplateBuilder/ButtonTemplateBuilder.php
@@ -58,8 +58,15 @@ class ButtonTemplateBuilder implements TemplateBuilder
      * @param string|null $imageSize
      * @param string|null $imageBackgroundColor
      */
-    public function __construct($title, $text, $thumbnailImageUrl, array $actionBuilders, $imageAspectRatio = null, $imageSize = null, $imageBackgroundColor = null)
-    {
+    public function __construct(
+        $title,
+        $text,
+        $thumbnailImageUrl,
+        array $actionBuilders,
+        $imageAspectRatio = null,
+        $imageSize = null,
+        $imageBackgroundColor = null
+    ) {
         $this->title = $title;
         $this->text = $text;
         $this->thumbnailImageUrl = $thumbnailImageUrl;

--- a/src/LINEBot/MessageBuilder/TemplateBuilder/CarouselColumnTemplateBuilder.php
+++ b/src/LINEBot/MessageBuilder/TemplateBuilder/CarouselColumnTemplateBuilder.php
@@ -34,6 +34,8 @@ class CarouselColumnTemplateBuilder implements TemplateBuilder
     private $text;
     /** @var string */
     private $thumbnailImageUrl;
+    /** @var string */
+    private $imageBackgroundColor;
     /** @var TemplateActionBuilder[] */
     private $actionBuilders;
 
@@ -47,13 +49,15 @@ class CarouselColumnTemplateBuilder implements TemplateBuilder
      * @param string $text
      * @param string $thumbnailImageUrl
      * @param TemplateActionBuilder[] $actionBuilders
+     * @param string|null $imageBackgroundColor
      */
-    public function __construct($title, $text, $thumbnailImageUrl, array $actionBuilders)
+    public function __construct($title, $text, $thumbnailImageUrl, array $actionBuilders, $imageBackgroundColor = null)
     {
         $this->title = $title;
         $this->text = $text;
         $this->thumbnailImageUrl = $thumbnailImageUrl;
         $this->actionBuilders = $actionBuilders;
+        $this->imageBackgroundColor = $imageBackgroundColor;
     }
 
     /**
@@ -78,6 +82,10 @@ class CarouselColumnTemplateBuilder implements TemplateBuilder
             'text' => $this->text,
             'actions' => $actions,
         ];
+
+        if ($this->imageBackgroundColor) {
+            $this->template['imageBackgroundColor'] = $this->imageBackgroundColor;
+        }
 
         return $this->template;
     }

--- a/src/LINEBot/MessageBuilder/TemplateBuilder/CarouselTemplateBuilder.php
+++ b/src/LINEBot/MessageBuilder/TemplateBuilder/CarouselTemplateBuilder.php
@@ -30,6 +30,10 @@ class CarouselTemplateBuilder implements TemplateBuilder
 {
     /** @var CarouselColumnTemplateBuilder[] */
     private $columnTemplateBuilders;
+    /** @var string */
+    private $imageAspectRatio;
+    /** @var string */
+    private $imageSize;
 
     /** @var array */
     private $template;
@@ -38,10 +42,14 @@ class CarouselTemplateBuilder implements TemplateBuilder
      * CarouselTemplateBuilder constructor.
      *
      * @param CarouselColumnTemplateBuilder[] $columnTemplateBuilders
+     * @param string|null $imageAspectRatio
+     * @param string|null $imageSize
      */
-    public function __construct(array $columnTemplateBuilders)
+    public function __construct(array $columnTemplateBuilders, $imageAspectRatio = null, $imageSize = null)
     {
         $this->columnTemplateBuilders = $columnTemplateBuilders;
+        $this->imageAspectRatio = $imageAspectRatio;
+        $this->imageSize = $imageSize;
     }
 
     /**
@@ -64,6 +72,14 @@ class CarouselTemplateBuilder implements TemplateBuilder
             'type' => TemplateType::CAROUSEL,
             'columns' => $columns,
         ];
+
+        if ($this->imageAspectRatio) {
+            $this->template['imageAspectRatio'] = $this->imageAspectRatio;
+        }
+
+        if ($this->imageSize) {
+            $this->template['imageSize'] = $this->imageSize;
+        }
 
         return $this->template;
     }

--- a/tests/LINEBot/MessageBuilder/TemplateBuilder/ButtonTemplateBuilderTest.php
+++ b/tests/LINEBot/MessageBuilder/TemplateBuilder/ButtonTemplateBuilderTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+namespace LINE\Tests\LINEBot\MessageBuilder\TemplateBuilder;
+
+use LINE\LINEBot\MessageBuilder\TemplateBuilder\ButtonTemplateBuilder;
+use LINE\LINEBot\TemplateActionBuilder\PostbackTemplateActionBuilder;
+use LINE\LINEBot\TemplateActionBuilder\UriTemplateActionBuilder;
+use LINE\LINEBot\TemplateActionBuilder\MessageTemplateActionBuilder;
+use PHPUnit\Framework\TestCase;
+
+class ButtonTemplateBuilderTest extends TestCase
+{
+
+    var $tests = [
+        [
+            'param' => ['aaa', 'bbb', 'ccc', ['postback', 'message', 'uri']],
+            'json' => <<<JSON
+{
+  "type":"buttons",
+  "thumbnailImageUrl":"ccc",
+  "title":"aaa",
+  "text":"bbb",
+  "actions":[
+    {"type":"postback","label":"AAA","data":"BBB"},
+    {"type":"message","label":"CCC","text":"DDD"},
+    {"type":"uri","label":"EEE","uri":"FFF"}
+  ]
+}
+JSON
+        ],
+        [
+            'param' => ['aaa', 'bbb', 'ccc', ['message', 'uri'], null, null, null],
+            'json' => <<<JSON
+{
+  "type":"buttons",
+  "thumbnailImageUrl":"ccc",
+  "title":"aaa",
+  "text":"bbb",
+  "actions":[
+    {"type":"message","label":"CCC","text":"DDD"},
+    {"type":"uri","label":"EEE","uri":"FFF"}
+  ]
+}
+JSON
+        ],
+        [
+            'param' => ['aaa', 'bbb', 'ccc', ['postback'], 'ddd'],
+            'json' => <<<JSON
+{
+  "type":"buttons",
+  "thumbnailImageUrl":"ccc",
+  "title":"aaa",
+  "text":"bbb",
+  "actions":[
+    {"type":"postback","label":"AAA","data":"BBB"}
+  ],
+  "imageAspectRatio":"ddd"
+}
+JSON
+        ],
+        [
+            'param' => ['aaa', 'bbb', 'ccc', ['message'], 'ddd', 'eee'],
+            'json' => <<<JSON
+{
+  "type":"buttons",
+  "thumbnailImageUrl":"ccc",
+  "title":"aaa",
+  "text":"bbb",
+  "actions":[
+    {"type":"message","label":"CCC","text":"DDD"}
+  ],
+  "imageAspectRatio":"ddd",
+  "imageSize":"eee"
+}
+JSON
+        ],
+        [
+            'param' => ['aaa', 'bbb', 'ccc', ['uri'], 'ddd', 'eee', 'fff'],
+            'json' => <<<JSON
+{
+  "type":"buttons",
+  "thumbnailImageUrl":"ccc",
+  "title":"aaa",
+  "text":"bbb",
+  "actions":[
+    {"type":"uri","label":"EEE","uri":"FFF"}
+  ],
+  "imageAspectRatio":"ddd",
+  "imageSize":"eee",
+  "imageBackgroundColor":"fff"
+}
+JSON
+        ],
+    ];
+
+    public function test()
+    {
+        $postbackActionBuilder = new PostbackTemplateActionBuilder('AAA', 'BBB');
+        $messageTemplateActionBuilder = new MessageTemplateActionBuilder('CCC', 'DDD');
+        $uriTemplateActionBuilder = new UriTemplateActionBuilder('EEE', 'FFF');
+
+        foreach ($this->tests as $t) {
+            $title = $t['param'][0];
+            $text = $t['param'][1];
+            $thumbnailImageUrl = $t['param'][2];
+            if (is_array($t['param'][3])) {
+                $actionBuilders = [];
+                if (in_array('postback', $t['param'][3]))
+                    $actionBuilders[] = $postbackActionBuilder;
+                if (in_array('message', $t['param'][3]))
+                    $actionBuilders[] = $messageTemplateActionBuilder;
+                if (in_array('uri', $t['param'][3]))
+                    $actionBuilders[] = $uriTemplateActionBuilder;
+            } else {
+                $actionBuilders = null;
+            }
+            $imageAspectRatio = isset($t['param'][4]) ? $t['param'][4] : null;
+            $imageSize = isset($t['param'][5]) ? $t['param'][5] : null;
+            $imageBackgroundColor = isset($t['param'][6]) ? $t['param'][6] : null;
+
+            if(count($t['param']) == 7) {
+                $templateBuilder = new ButtonTemplateBuilder($title, $text, $thumbnailImageUrl, $actionBuilders, $imageAspectRatio, $imageSize, $imageBackgroundColor);
+            } elseif(count($t['param']) == 6) {
+                $templateBuilder = new ButtonTemplateBuilder($title, $text, $thumbnailImageUrl, $actionBuilders, $imageAspectRatio, $imageSize);
+            } elseif(count($t['param']) == 5) {
+                $templateBuilder = new ButtonTemplateBuilder($title, $text, $thumbnailImageUrl, $actionBuilders, $imageAspectRatio);
+            } else {
+                $templateBuilder = new ButtonTemplateBuilder($title, $text, $thumbnailImageUrl, $actionBuilders);
+            }
+
+            $this->assertEquals($templateBuilder->buildTemplate(), json_decode($t['json'], true));
+        }
+    }
+}

--- a/tests/LINEBot/MessageBuilder/TemplateBuilder/ButtonTemplateBuilderTest.php
+++ b/tests/LINEBot/MessageBuilder/TemplateBuilder/ButtonTemplateBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2016 LINE Corporation
+ * Copyright 2018 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/tests/LINEBot/MessageBuilder/TemplateBuilder/ButtonTemplateBuilderTest.php
+++ b/tests/LINEBot/MessageBuilder/TemplateBuilder/ButtonTemplateBuilderTest.php
@@ -26,7 +26,7 @@ use PHPUnit\Framework\TestCase;
 class ButtonTemplateBuilderTest extends TestCase
 {
 
-    var $tests = [
+    private static $tests = [
         [
             'param' => ['aaa', 'bbb', 'ccc', ['postback', 'message', 'uri']],
             'json' => <<<JSON
@@ -114,18 +114,21 @@ JSON
         $messageTemplateActionBuilder = new MessageTemplateActionBuilder('CCC', 'DDD');
         $uriTemplateActionBuilder = new UriTemplateActionBuilder('EEE', 'FFF');
 
-        foreach ($this->tests as $t) {
+        foreach (self::$tests as $t) {
             $title = $t['param'][0];
             $text = $t['param'][1];
             $thumbnailImageUrl = $t['param'][2];
             if (is_array($t['param'][3])) {
                 $actionBuilders = [];
-                if (in_array('postback', $t['param'][3]))
+                if (in_array('postback', $t['param'][3])) {
                     $actionBuilders[] = $postbackActionBuilder;
-                if (in_array('message', $t['param'][3]))
+                }
+                if (in_array('message', $t['param'][3])) {
                     $actionBuilders[] = $messageTemplateActionBuilder;
-                if (in_array('uri', $t['param'][3]))
+                }
+                if (in_array('uri', $t['param'][3])) {
                     $actionBuilders[] = $uriTemplateActionBuilder;
+                }
             } else {
                 $actionBuilders = null;
             }
@@ -133,14 +136,40 @@ JSON
             $imageSize = isset($t['param'][5]) ? $t['param'][5] : null;
             $imageBackgroundColor = isset($t['param'][6]) ? $t['param'][6] : null;
 
-            if(count($t['param']) == 7) {
-                $templateBuilder = new ButtonTemplateBuilder($title, $text, $thumbnailImageUrl, $actionBuilders, $imageAspectRatio, $imageSize, $imageBackgroundColor);
-            } elseif(count($t['param']) == 6) {
-                $templateBuilder = new ButtonTemplateBuilder($title, $text, $thumbnailImageUrl, $actionBuilders, $imageAspectRatio, $imageSize);
-            } elseif(count($t['param']) == 5) {
-                $templateBuilder = new ButtonTemplateBuilder($title, $text, $thumbnailImageUrl, $actionBuilders, $imageAspectRatio);
+            if (count($t['param']) == 7) {
+                $templateBuilder = new ButtonTemplateBuilder(
+                    $title,
+                    $text,
+                    $thumbnailImageUrl,
+                    $actionBuilders,
+                    $imageAspectRatio,
+                    $imageSize,
+                    $imageBackgroundColor
+                );
+            } elseif (count($t['param']) == 6) {
+                $templateBuilder = new ButtonTemplateBuilder(
+                    $title,
+                    $text,
+                    $thumbnailImageUrl,
+                    $actionBuilders,
+                    $imageAspectRatio,
+                    $imageSize
+                );
+            } elseif (count($t['param']) == 5) {
+                $templateBuilder = new ButtonTemplateBuilder(
+                    $title,
+                    $text,
+                    $thumbnailImageUrl,
+                    $actionBuilders,
+                    $imageAspectRatio
+                );
             } else {
-                $templateBuilder = new ButtonTemplateBuilder($title, $text, $thumbnailImageUrl, $actionBuilders);
+                $templateBuilder = new ButtonTemplateBuilder(
+                    $title,
+                    $text,
+                    $thumbnailImageUrl,
+                    $actionBuilders
+                );
             }
 
             $this->assertEquals($templateBuilder->buildTemplate(), json_decode($t['json'], true));

--- a/tests/LINEBot/MessageBuilder/TemplateBuilder/CarouselColumnTemplateBuilderTest.php
+++ b/tests/LINEBot/MessageBuilder/TemplateBuilder/CarouselColumnTemplateBuilderTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+namespace LINE\Tests\LINEBot\MessageBuilder\TemplateBuilder;
+
+use LINE\LINEBot\MessageBuilder\TemplateBuilder\CarouselColumnTemplateBuilder;
+use LINE\LINEBot\TemplateActionBuilder\PostbackTemplateActionBuilder;
+use LINE\LINEBot\TemplateActionBuilder\UriTemplateActionBuilder;
+use LINE\LINEBot\TemplateActionBuilder\MessageTemplateActionBuilder;
+use PHPUnit\Framework\TestCase;
+
+class CarouselColumnTemplateBuilderTest extends TestCase
+{
+
+    var $tests = [
+        [
+            'param' => ['aaa', 'bbb', 'ccc', ['postback', 'message', 'uri']],
+            'json' => <<<JSON
+{
+  "thumbnailImageUrl":"ccc",
+  "title":"aaa",
+  "text":"bbb",
+  "actions":[
+    {"type":"postback", "label":"AAA", "data":"BBB"},
+    {"type":"message", "label":"CCC", "text":"DDD"},
+    {"type":"uri", "label":"EEE", "uri":"FFF"}
+  ]
+}
+JSON
+        ],
+        [
+            'param' => ['aaa', 'bbb', 'ccc', ['message', 'uri'], null],
+            'json' => <<<JSON
+{
+  "thumbnailImageUrl":"ccc",
+  "title":"aaa",
+  "text":"bbb",
+  "actions":[
+    {"type":"message", "label":"CCC", "text":"DDD"},
+    {"type":"uri", "label":"EEE", "uri":"FFF"}
+  ]
+}
+JSON
+        ],
+        [
+            'param' => ['aaa', 'bbb', 'ccc', ['postback'], 'ddd'],
+            'json' => <<<JSON
+{
+  "thumbnailImageUrl":"ccc",
+  "title":"aaa",
+  "text":"bbb",
+  "actions":[
+    {"type":"postback","label":"AAA","data":"BBB"}
+  ],
+  "imageBackgroundColor":"ddd"
+}
+JSON
+        ],
+    ];
+
+    public function test()
+    {
+        $postbackActionBuilder = new PostbackTemplateActionBuilder('AAA', 'BBB');
+        $messageTemplateActionBuilder = new MessageTemplateActionBuilder('CCC', 'DDD');
+        $uriTemplateActionBuilder = new UriTemplateActionBuilder('EEE', 'FFF');
+
+        foreach ($this->tests as $t) {
+            $title = $t['param'][0];
+            $text = $t['param'][1];
+            $thumbnailImageUrl = $t['param'][2];
+            if (is_array($t['param'][3])) {
+                $actionBuilders = [];
+                if (in_array('postback', $t['param'][3]))
+                    $actionBuilders[] = $postbackActionBuilder;
+                if (in_array('message', $t['param'][3]))
+                    $actionBuilders[] = $messageTemplateActionBuilder;
+                if (in_array('uri', $t['param'][3]))
+                    $actionBuilders[] = $uriTemplateActionBuilder;
+            } else {
+                $actionBuilders = null;
+            }
+            $imageBackgroundColor = isset($t['param'][4]) ? $t['param'][4] : null;
+
+            if(count($t['param']) == 5) {
+                $builder = new CarouselColumnTemplateBuilder($title, $text, $thumbnailImageUrl, $actionBuilders, $imageBackgroundColor);
+            } else {
+                $builder = new CarouselColumnTemplateBuilder($title, $text, $thumbnailImageUrl, $actionBuilders);
+            }
+
+            $this->assertEquals($builder->buildTemplate(), json_decode($t['json'], true));
+        }
+    }
+}

--- a/tests/LINEBot/MessageBuilder/TemplateBuilder/CarouselColumnTemplateBuilderTest.php
+++ b/tests/LINEBot/MessageBuilder/TemplateBuilder/CarouselColumnTemplateBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2016 LINE Corporation
+ * Copyright 2018 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/tests/LINEBot/MessageBuilder/TemplateBuilder/CarouselColumnTemplateBuilderTest.php
+++ b/tests/LINEBot/MessageBuilder/TemplateBuilder/CarouselColumnTemplateBuilderTest.php
@@ -26,7 +26,7 @@ use PHPUnit\Framework\TestCase;
 class CarouselColumnTemplateBuilderTest extends TestCase
 {
 
-    var $tests = [
+    private static $tests = [
         [
             'param' => ['aaa', 'bbb', 'ccc', ['postback', 'message', 'uri']],
             'json' => <<<JSON
@@ -35,12 +35,13 @@ class CarouselColumnTemplateBuilderTest extends TestCase
   "title":"aaa",
   "text":"bbb",
   "actions":[
-    {"type":"postback", "label":"AAA", "data":"BBB"},
-    {"type":"message", "label":"CCC", "text":"DDD"},
-    {"type":"uri", "label":"EEE", "uri":"FFF"}
+    {"type":"postback","label":"AAA","data":"BBB"},
+    {"type":"message","label":"CCC","text":"DDD"},
+    {"type":"uri","label":"EEE","uri":"FFF"}
   ]
 }
 JSON
+
         ],
         [
             'param' => ['aaa', 'bbb', 'ccc', ['message', 'uri'], null],
@@ -50,11 +51,12 @@ JSON
   "title":"aaa",
   "text":"bbb",
   "actions":[
-    {"type":"message", "label":"CCC", "text":"DDD"},
-    {"type":"uri", "label":"EEE", "uri":"FFF"}
+    {"type":"message","label":"CCC","text":"DDD"},
+    {"type":"uri","label":"EEE","uri":"FFF"}
   ]
 }
 JSON
+
         ],
         [
             'param' => ['aaa', 'bbb', 'ccc', ['postback'], 'ddd'],
@@ -78,27 +80,41 @@ JSON
         $messageTemplateActionBuilder = new MessageTemplateActionBuilder('CCC', 'DDD');
         $uriTemplateActionBuilder = new UriTemplateActionBuilder('EEE', 'FFF');
 
-        foreach ($this->tests as $t) {
+        foreach (self::$tests as $t) {
             $title = $t['param'][0];
             $text = $t['param'][1];
             $thumbnailImageUrl = $t['param'][2];
             if (is_array($t['param'][3])) {
                 $actionBuilders = [];
-                if (in_array('postback', $t['param'][3]))
+                if (in_array('postback', $t['param'][3])) {
                     $actionBuilders[] = $postbackActionBuilder;
-                if (in_array('message', $t['param'][3]))
+                }
+                if (in_array('message', $t['param'][3])) {
                     $actionBuilders[] = $messageTemplateActionBuilder;
-                if (in_array('uri', $t['param'][3]))
+                }
+                if (in_array('uri', $t['param'][3])) {
                     $actionBuilders[] = $uriTemplateActionBuilder;
+                }
             } else {
                 $actionBuilders = null;
             }
             $imageBackgroundColor = isset($t['param'][4]) ? $t['param'][4] : null;
 
-            if(count($t['param']) == 5) {
-                $builder = new CarouselColumnTemplateBuilder($title, $text, $thumbnailImageUrl, $actionBuilders, $imageBackgroundColor);
+            if (count($t['param']) == 5) {
+                $builder = new CarouselColumnTemplateBuilder(
+                    $title,
+                    $text,
+                    $thumbnailImageUrl,
+                    $actionBuilders,
+                    $imageBackgroundColor
+                );
             } else {
-                $builder = new CarouselColumnTemplateBuilder($title, $text, $thumbnailImageUrl, $actionBuilders);
+                $builder = new CarouselColumnTemplateBuilder(
+                    $title,
+                    $text,
+                    $thumbnailImageUrl,
+                    $actionBuilders
+                );
             }
 
             $this->assertEquals($builder->buildTemplate(), json_decode($t['json'], true));

--- a/tests/LINEBot/MessageBuilder/TemplateBuilder/CarouselTemplateBuilderTest.php
+++ b/tests/LINEBot/MessageBuilder/TemplateBuilder/CarouselTemplateBuilderTest.php
@@ -27,16 +27,16 @@ use PHPUnit\Framework\TestCase;
 class CarouselTemplateBuilderTest extends TestCase
 {
 
-    var $tests = [
+    private static $tests = [
         [
             'param' => [['postback', 'message', 'uri']],
             'json' => <<<JSON
 {
   "type":"carousel",
-  "columns": [
-    {"thumbnailImageUrl":"ccc", "title":"aaa", "text":"bbb", "actions":[{"type":"postback", "label":"AAA", "data":"BBB"}]},
-    {"thumbnailImageUrl":"ccc", "title":"aaa", "text":"bbb", "actions":[{"type":"message", "label":"CCC", "text":"DDD"}]},
-    {"thumbnailImageUrl":"ccc", "title":"aaa", "text":"bbb", "actions":[{"type":"uri", "label":"EEE", "uri":"FFF"}]}
+  "columns":[
+    {"thumbnailImageUrl":"ccc","title":"aaa","text":"bbb","actions":[{"type":"postback","label":"AAA","data":"BBB"}]},
+    {"thumbnailImageUrl":"ccc","title":"aaa","text":"bbb","actions":[{"type":"message","label":"CCC","text":"DDD"}]},
+    {"thumbnailImageUrl":"ccc","title":"aaa","text":"bbb","actions":[{"type":"uri","label":"EEE","uri":"FFF"}]}
   ]
 }
 JSON
@@ -46,9 +46,9 @@ JSON
             'json' => <<<JSON
 {
   "type":"carousel",
-  "columns": [
-    {"thumbnailImageUrl":"ccc", "title":"aaa", "text":"bbb", "actions":[{"type":"message", "label":"CCC", "text":"DDD"}]},
-    {"thumbnailImageUrl":"ccc", "title":"aaa", "text":"bbb", "actions":[{"type":"uri", "label":"EEE", "uri":"FFF"}]}
+  "columns":[
+    {"thumbnailImageUrl":"ccc","title":"aaa","text":"bbb","actions":[{"type":"message","label":"CCC","text":"DDD"}]},
+    {"thumbnailImageUrl":"ccc","title":"aaa","text":"bbb","actions":[{"type":"uri","label":"EEE","uri":"FFF"}]}
   ]
 }
 JSON
@@ -58,8 +58,8 @@ JSON
             'json' => <<<JSON
 {
   "type":"carousel",
-  "columns": [
-    {"thumbnailImageUrl":"ccc", "title":"aaa", "text":"bbb", "actions":[{"type":"postback", "label":"AAA", "data":"BBB"}]}
+  "columns":[
+    {"thumbnailImageUrl":"ccc","title":"aaa","text":"bbb","actions":[{"type":"postback","label":"AAA","data":"BBB"}]}
   ],
   "imageAspectRatio":"ddd"
 }
@@ -71,7 +71,7 @@ JSON
 {
   "type":"carousel",
   "columns":[
-    {"thumbnailImageUrl":"ccc", "title":"aaa", "text":"bbb", "actions":[{"type":"message", "label":"CCC", "text":"DDD"}]}
+    {"thumbnailImageUrl":"ccc","title":"aaa","text":"bbb","actions":[{"type":"message","label":"CCC","text":"DDD"}]}
   ],
   "imageAspectRatio":"ddd",
   "imageSize":"eee"
@@ -91,24 +91,27 @@ JSON
         $messageTemplateActionBuilder = $this->carouselTemplateBuilder(new MessageTemplateActionBuilder('CCC', 'DDD'));
         $uriTemplateActionBuilder = $this->carouselTemplateBuilder(new UriTemplateActionBuilder('EEE', 'FFF'));
 
-        foreach ($this->tests as $t) {
+        foreach (self::$tests as $t) {
             if (is_array($t['param'][0])) {
                 $columnTemplateBuilders= [];
-                if (in_array('postback', $t['param'][0]))
+                if (in_array('postback', $t['param'][0])) {
                     $columnTemplateBuilders[] = $postbackActionBuilder;
-                if (in_array('message', $t['param'][0]))
+                }
+                if (in_array('message', $t['param'][0])) {
                     $columnTemplateBuilders[] = $messageTemplateActionBuilder;
-                if (in_array('uri', $t['param'][0]))
+                }
+                if (in_array('uri', $t['param'][0])) {
                     $columnTemplateBuilders[] = $uriTemplateActionBuilder;
+                }
             } else {
                 $columnTemplateBuilders= null;
             }
             $imageAspectRatio = isset($t['param'][1]) ? $t['param'][1] : null;
             $imageSize = isset($t['param'][2]) ? $t['param'][2] : null;
 
-            if(count($t['param']) == 3) {
+            if (count($t['param']) == 3) {
                 $templateBuilder = new CarouselTemplateBuilder($columnTemplateBuilders, $imageAspectRatio, $imageSize);
-            } elseif(count($t['param']) == 2) {
+            } elseif (count($t['param']) == 2) {
                 $templateBuilder = new CarouselTemplateBuilder($columnTemplateBuilders, $imageAspectRatio);
             } else {
                 $templateBuilder = new CarouselTemplateBuilder($columnTemplateBuilders);

--- a/tests/LINEBot/MessageBuilder/TemplateBuilder/CarouselTemplateBuilderTest.php
+++ b/tests/LINEBot/MessageBuilder/TemplateBuilder/CarouselTemplateBuilderTest.php
@@ -104,7 +104,7 @@ JSON
                     $columnTemplateBuilders[] = $uriTemplateActionBuilder;
                 }
             } else {
-                $columnTemplateBuilders= null;
+                $columnTemplateBuilders = null;
             }
             $imageAspectRatio = isset($t['param'][1]) ? $t['param'][1] : null;
             $imageSize = isset($t['param'][2]) ? $t['param'][2] : null;

--- a/tests/LINEBot/MessageBuilder/TemplateBuilder/CarouselTemplateBuilderTest.php
+++ b/tests/LINEBot/MessageBuilder/TemplateBuilder/CarouselTemplateBuilderTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+namespace LINE\Tests\LINEBot\MessageBuilder\TemplateBuilder;
+
+use LINE\LINEBot\MessageBuilder\TemplateBuilder\CarouselColumnTemplateBuilder;
+use LINE\LINEBot\MessageBuilder\TemplateBuilder\CarouselTemplateBuilder;
+use LINE\LINEBot\TemplateActionBuilder\PostbackTemplateActionBuilder;
+use LINE\LINEBot\TemplateActionBuilder\UriTemplateActionBuilder;
+use LINE\LINEBot\TemplateActionBuilder\MessageTemplateActionBuilder;
+use PHPUnit\Framework\TestCase;
+
+class CarouselTemplateBuilderTest extends TestCase
+{
+
+    var $tests = [
+        [
+            'param' => [['postback', 'message', 'uri']],
+            'json' => <<<JSON
+{
+  "type":"carousel",
+  "columns": [
+    {"thumbnailImageUrl":"ccc", "title":"aaa", "text":"bbb", "actions":[{"type":"postback", "label":"AAA", "data":"BBB"}]},
+    {"thumbnailImageUrl":"ccc", "title":"aaa", "text":"bbb", "actions":[{"type":"message", "label":"CCC", "text":"DDD"}]},
+    {"thumbnailImageUrl":"ccc", "title":"aaa", "text":"bbb", "actions":[{"type":"uri", "label":"EEE", "uri":"FFF"}]}
+  ]
+}
+JSON
+        ],
+        [
+            'param' => [['message', 'uri'], null, null],
+            'json' => <<<JSON
+{
+  "type":"carousel",
+  "columns": [
+    {"thumbnailImageUrl":"ccc", "title":"aaa", "text":"bbb", "actions":[{"type":"message", "label":"CCC", "text":"DDD"}]},
+    {"thumbnailImageUrl":"ccc", "title":"aaa", "text":"bbb", "actions":[{"type":"uri", "label":"EEE", "uri":"FFF"}]}
+  ]
+}
+JSON
+        ],
+        [
+            'param' => [['postback'], 'ddd'],
+            'json' => <<<JSON
+{
+  "type":"carousel",
+  "columns": [
+    {"thumbnailImageUrl":"ccc", "title":"aaa", "text":"bbb", "actions":[{"type":"postback", "label":"AAA", "data":"BBB"}]}
+  ],
+  "imageAspectRatio":"ddd"
+}
+JSON
+        ],
+        [
+            'param' => [['message'], 'ddd', 'eee'],
+            'json' => <<<JSON
+{
+  "type":"carousel",
+  "columns":[
+    {"thumbnailImageUrl":"ccc", "title":"aaa", "text":"bbb", "actions":[{"type":"message", "label":"CCC", "text":"DDD"}]}
+  ],
+  "imageAspectRatio":"ddd",
+  "imageSize":"eee"
+}
+JSON
+        ],
+    ];
+
+    private function carouselTemplateBuilder($actionBuilder)
+    {
+        return new CarouselColumnTemplateBuilder('aaa', 'bbb', 'ccc', [$actionBuilder]);
+    }
+
+    public function test()
+    {
+        $postbackActionBuilder = $this->carouselTemplateBuilder(new PostbackTemplateActionBuilder('AAA', 'BBB'));
+        $messageTemplateActionBuilder = $this->carouselTemplateBuilder(new MessageTemplateActionBuilder('CCC', 'DDD'));
+        $uriTemplateActionBuilder = $this->carouselTemplateBuilder(new UriTemplateActionBuilder('EEE', 'FFF'));
+
+        foreach ($this->tests as $t) {
+            if (is_array($t['param'][0])) {
+                $columnTemplateBuilders= [];
+                if (in_array('postback', $t['param'][0]))
+                    $columnTemplateBuilders[] = $postbackActionBuilder;
+                if (in_array('message', $t['param'][0]))
+                    $columnTemplateBuilders[] = $messageTemplateActionBuilder;
+                if (in_array('uri', $t['param'][0]))
+                    $columnTemplateBuilders[] = $uriTemplateActionBuilder;
+            } else {
+                $columnTemplateBuilders= null;
+            }
+            $imageAspectRatio = isset($t['param'][1]) ? $t['param'][1] : null;
+            $imageSize = isset($t['param'][2]) ? $t['param'][2] : null;
+
+            if(count($t['param']) == 3) {
+                $templateBuilder = new CarouselTemplateBuilder($columnTemplateBuilders, $imageAspectRatio, $imageSize);
+            } elseif(count($t['param']) == 2) {
+                $templateBuilder = new CarouselTemplateBuilder($columnTemplateBuilders, $imageAspectRatio);
+            } else {
+                $templateBuilder = new CarouselTemplateBuilder($columnTemplateBuilders);
+            }
+
+            $this->assertEquals($templateBuilder->buildTemplate(), json_decode($t['json'], true));
+        }
+    }
+}

--- a/tests/LINEBot/MessageBuilder/TemplateBuilder/CarouselTemplateBuilderTest.php
+++ b/tests/LINEBot/MessageBuilder/TemplateBuilder/CarouselTemplateBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2016 LINE Corporation
+ * Copyright 2018 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/tests/LINEBot/SendTemplateTest.php
+++ b/tests/LINEBot/SendTemplateTest.php
@@ -131,6 +131,10 @@ class SendTemplateTest extends TestCase
             $testRunner->assertEquals('uri label', $actions[3]['label']);
             $testRunner->assertEquals('https://example.com', $actions[3]['uri']);
 
+            $testRunner->assertEquals('rectangle', $template['imageAspectRatio']);
+            $testRunner->assertEquals('cover', $template['imageSize']);
+            $testRunner->assertEquals('#FFFFFF', $template['imageBackgroundColor']);
+
             return ['status' => 200];
         };
         $bot = new LINEBot(new DummyHttpClient($this, $mock), ['channelSecret' => 'CHANNEL-SECRET']);
@@ -147,7 +151,10 @@ class SendTemplateTest extends TestCase
                         new PostbackTemplateActionBuilder('postback label2', 'post=back2', 'extend text'),
                         new MessageTemplateActionBuilder('message label', 'test message'),
                         new UriTemplateActionBuilder('uri label', 'https://example.com'),
-                    ]
+                    ],
+                    'rectangle',
+                    'cover',
+                    '#FFFFFF'
                 )
             )
         );


### PR DESCRIPTION
> We have released imageAspectRatio, imageSize, and imageBackgroundColor fields for Buttons and Carousel template messages. Using these fields, you can configure the aspect ratio, size, and background color for images used in template messages.
- https://github.com/line/line-bot-sdk-php/issues/133
- https://developers.line.me/en/news/2017/11/