### PR TITLE
Enhanced Messaging API features after redesign(04/18)

### DIFF
--- a/src/LINEBot.php
+++ b/src/LINEBot.php
@@ -159,13 +159,15 @@ class LINEBot
      *
      * @param string $to Identifier of destination.
      * @param MessageBuilder $messageBuilder Message builder to send.
+     * @param boolean $notificationDisabled Don't send push notifications(=true) or send(=false)
      * @return Response
      */
-    public function pushMessage($to, MessageBuilder $messageBuilder)
+    public function pushMessage($to, MessageBuilder $messageBuilder, $notificationDisabled = false)
     {
         return $this->httpClient->post($this->endpointBase . '/v2/bot/message/push', [
             'to' => $to,
             'messages' => $messageBuilder->buildMessage(),
+            'notificationDisabled' => $notificationDisabled,
         ]);
     }
 
@@ -174,13 +176,31 @@ class LINEBot
      *
      * @param array $tos Identifiers of destination.
      * @param MessageBuilder $messageBuilder Message builder to send.
+     * @param boolean $notificationDisabled Don't send push notifications(=true) or send(=false)
      * @return Response
      */
-    public function multicast(array $tos, MessageBuilder $messageBuilder)
+    public function multicast(array $tos, MessageBuilder $messageBuilder, $notificationDisabled = false)
     {
         return $this->httpClient->post($this->endpointBase . '/v2/bot/message/multicast', [
             'to' => $tos,
             'messages' => $messageBuilder->buildMessage(),
+            'notificationDisabled' => $notificationDisabled,
+        ]);
+    }
+
+    /**
+     * Sends push messages to multiple users at any time.
+     * LINE@ accounts cannot call this API endpoint. Please migrate it to a LINE official account.
+     *
+     * @param MessageBuilder $messageBuilder Message builder to send.
+     * @param boolean $notificationDisabled Don't send push notifications(=true) or send(=false)
+     * @return Response
+     */
+    public function broadcast(MessageBuilder $messageBuilder, $notificationDisabled = false)
+    {
+        return $this->httpClient->post($this->endpointBase . '/v2/bot/message/broadcast', [
+            'messages' => $messageBuilder->buildMessage(),
+            'notificationDisabled' => $notificationDisabled,
         ]);
     }
 
@@ -550,6 +570,19 @@ class LINEBot
     public function getNumberOfSentMulticastMessages(DateTime $datetime)
     {
         $url = $this->endpointBase . '/v2/bot/message/delivery/multicast';
+        $datetime->setTimezone(new DateTimeZone('Asia/Tokyo'));
+        return $this->httpClient->get($url, ['date' => $datetime->format('Ymd')]);
+    }
+
+    /**
+     * Get number of sent broadcast messages
+     *
+     * @param DateTime $datetime Date the messages were sent.
+     * @return Response
+     */
+    public function getNumberOfSentBroadcastMessages(DateTime $datetime)
+    {
+        $url = $this->endpointBase . '/v2/bot/message/delivery/broadcast';
         $datetime->setTimezone(new DateTimeZone('Asia/Tokyo'));
         return $this->httpClient->get($url, ['date' => $datetime->format('Ymd')]);
     }

--- a/src/LINEBot.php
+++ b/src/LINEBot.php
@@ -86,6 +86,26 @@ class LINEBot
     }
 
     /**
+     * Gets the target limit for additional messages in the current month.
+     *
+     * @return Response
+     */
+    public function getNumberOfLimitForAdditional()
+    {
+        return $this->httpClient->get($this->endpointBase . '/v2/bot/message/quota');
+    }
+
+    /**
+     * Gets the number of messages sent in the current month.
+     *
+     * @return Response
+     */
+    public function getNumberOfSentThisMonth()
+    {
+        return $this->httpClient->get($this->endpointBase . '/v2/bot/message/quota/consumption');
+    }
+
+    /**
      * Replies arbitrary message to destination which is associated with reply token.
      *
      * @param string $replyToken Identifier of destination.

--- a/tests/LINEBot/GetNumberOfSendMessagesTest.php
+++ b/tests/LINEBot/GetNumberOfSendMessagesTest.php
@@ -171,4 +171,31 @@ class GetNumberOfMessagesSentTest extends TestCase
         $data = $res->getJSONDecodedBody();
         $this->assertEquals(10000, $data['totalUsage']);
     }
+
+    public function testGetNumberOfSentBroadcastMessages()
+    {
+        $date = new DateTime();
+        $mock = function ($testRunner, $httpMethod, $url, $data) use ($date) {
+            /** @var \PHPUnit\Framework\TestCase $testRunner */
+            $testRunner->assertEquals('GET', $httpMethod);
+            $testRunner->assertEquals('https://api.line.me/v2/bot/message/delivery/broadcast', $url);
+            $date->setTimezone(new DateTimeZone('Asia/Tokyo'));
+            $testRunner->assertEquals([
+                'date' => $date->format('Ymd')
+            ], $data);
+            return [
+                'status' => 'ready',
+                'success' => 10000
+            ];
+        };
+        $bot = new LINEBot(new DummyHttpClient($this, $mock), ['channelSecret' => 'CHANNEL-SECRET']);
+        $res = $bot->getNumberOfSentBroadcastMessages($date);
+
+        $this->assertEquals(200, $res->getHTTPStatus());
+        $this->assertTrue($res->isSucceeded());
+
+        $data = $res->getJSONDecodedBody();
+        $this->assertEquals('ready', $data['status']);
+        $this->assertEquals(10000, $data['success']);
+    }
 }

--- a/tests/LINEBot/GetNumberOfSendMessagesTest.php
+++ b/tests/LINEBot/GetNumberOfSendMessagesTest.php
@@ -106,4 +106,69 @@ class GetNumberOfMessagesSentTest extends TestCase
         $this->assertEquals('ready', $data['status']);
         $this->assertEquals(10000, $data['success']);
     }
+
+    public function testGetNumberOfLimitForAdditional()
+    {
+        // Test: type is 'limited'
+        $mock = function ($testRunner, $httpMethod, $url, $data) {
+            /** @var \PHPUnit\Framework\TestCase $testRunner */
+            $testRunner->assertEquals('GET', $httpMethod);
+            $testRunner->assertEquals('https://api.line.me/v2/bot/message/quota', $url);
+            $testRunner->assertEquals([], $data);
+            return [
+                'type' => 'limited',
+                'value' => 10000
+            ];
+        };
+        $bot = new LINEBot(new DummyHttpClient($this, $mock), ['channelSecret' => 'CHANNEL-SECRET']);
+        $res = $bot->getNumberOfLimitForAdditional();
+
+        $this->assertEquals(200, $res->getHTTPStatus());
+        $this->assertTrue($res->isSucceeded());
+
+        $data = $res->getJSONDecodedBody();
+        $this->assertEquals('limited', $data['type']);
+        $this->assertEquals(10000, $data['value']);
+
+        // Test: type is 'none'
+        $mock = function ($testRunner, $httpMethod, $url, $data) {
+            /** @var \PHPUnit\Framework\TestCase $testRunner */
+            $testRunner->assertEquals('GET', $httpMethod);
+            $testRunner->assertEquals('https://api.line.me/v2/bot/message/quota', $url);
+            $testRunner->assertEquals([], $data);
+            return [
+                'type' => 'none'
+            ];
+        };
+        $bot = new LINEBot(new DummyHttpClient($this, $mock), ['channelSecret' => 'CHANNEL-SECRET']);
+        $res = $bot->getNumberOfLimitForAdditional();
+
+        $this->assertEquals(200, $res->getHTTPStatus());
+        $this->assertTrue($res->isSucceeded());
+
+        $data = $res->getJSONDecodedBody();
+        $this->assertEquals('none', $data['type']);
+        $this->assertArrayNotHasKey('value', $data);
+    }
+
+    public function testGetNumberOfSentThisMonth()
+    {
+        $mock = function ($testRunner, $httpMethod, $url, $data) {
+            /** @var \PHPUnit\Framework\TestCase $testRunner */
+            $testRunner->assertEquals('GET', $httpMethod);
+            $testRunner->assertEquals('https://api.line.me/v2/bot/message/quota/consumption', $url);
+            $testRunner->assertEquals([], $data);
+            return [
+                'totalUsage' => 10000
+            ];
+        };
+        $bot = new LINEBot(new DummyHttpClient($this, $mock), ['channelSecret' => 'CHANNEL-SECRET']);
+        $res = $bot->getNumberOfSentThisMonth();
+
+        $this->assertEquals(200, $res->getHTTPStatus());
+        $this->assertTrue($res->isSucceeded());
+
+        $data = $res->getJSONDecodedBody();
+        $this->assertEquals(10000, $data['totalUsage']);
+    }
 }


### PR DESCRIPTION
Fixed https://github.com/line/line-bot-sdk-php/issues/224 .

## [Get the target limit for additional messages](https://developers.line.biz/en/reference/messaging-api/#get-quota)
* add support for "Get the target limit for additional messages api"

## [Get number of messages sent this month](https://developers.line.biz/en/reference/messaging-api/#get-consumption)
* add support for "Get number of messages sent this month api"

## [Send push message](https://developers.line.biz/en/reference/messaging-api/#send-push-message)
* add support for `notificationDisabled` param

## [Send multicast message](https://developers.line.biz/en/reference/messaging-api/#send-multicast-message)
* add support for `notificationDisabled` param

## [Send broadcast message](https://developers.line.biz/en/reference/messaging-api/#send-broadcast-message)
* add support for "Send broadcast message api"

## [Get number of sent broadcast messages](https://developers.line.biz/en/reference/messaging-api/#get-number-of-broadcast-messages)
* add support for "Get number of sent broadcast messages api"