### PR TITLE
Support connection checking from dashboard

### DIFF
--- a/line-bot-sdk-tiny/echo_bot.php
+++ b/line-bot-sdk-tiny/echo_bot.php
@@ -38,6 +38,9 @@ foreach ($client->parseEvents() as $event) {
                         ]
                     ]);
                     break;
+                case 'sticker':
+                    // For checking connection from LINE Developers dashboard
+                    http_response_code(200);
                 default:
                     error_log('Unsupported message type: ' . $message['type']);
                     break;


### PR DESCRIPTION
Webhook URL connection checker on LINE Developers dashboard will fail after copy and paste this code. Because the checker sends to the our server as a "sticker" type message, but now only "text" type messages are supported.

I don't know why LINE send as a "sticker" type and how we detect well that a message is for doing connection check. But it works. :P

[![Image from Gyazo](https://i.gyazo.com/a65f074868a282712b83aa632dc07e9b.png)](https://gyazo.com/a65f074868a282712b83aa632dc07e9b)