### PR TITLE
Remove unused symfony-libs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,6 @@
     "phpmd/phpmd": "~2.4",
     "squizlabs/php_codesniffer": "~2.6||^3",
     "indigophp/hash-compat": "~1.1.0",
-    "symfony/config": "^3.3",
-    "symfony/dependency-injection": "^3.3",
     "ext-posix": "*"
   },
   "suggest": {


### PR DESCRIPTION
fix this security alert.
https://github.com/line/line-bot-sdk-php/network/alert/composer.json/symfony%2Fdependency-injection/open