### PR TITLE
Add default rich menu features

### DIFF
--- a/src/LINEBot.php
+++ b/src/LINEBot.php
@@ -424,6 +424,40 @@ class LINEBot
     }
 
     /**
+     * Set the default rich menu.
+     *
+     * @param string $richMenuId ID of an uploaded rich menu
+     * @return Response
+     */
+    public function setDefaultRichMenuId($richMenuId)
+    {
+        $url = sprintf('%s/v2/bot/user/all/richmenu/%s', $this->endpointBase, urlencode($richMenuId));
+        return $this->httpClient->post($url, []);
+    }
+
+    /**
+     * Get the default rich menu ID.
+     *
+     * @return Response
+     */
+    public function getDefaultRichMenuId()
+    {
+        $url = $this->endpointBase . '/v2/bot/user/all/richmenu';
+        return $this->httpClient->get($url);
+    }
+
+    /**
+     * Cancel the default rich menu.
+     *
+     * @return Response
+     */
+    public function cancelDefaultRichMenuId()
+    {
+        $url = $this->endpointBase . '/v2/bot/user/all/richmenu';
+        return $this->httpClient->delete($url);
+    }
+
+    /**
      * Gets the ID of the rich menu linked to a user.
      *
      * @param string $userId User ID. Found in the source object of webhook event objects.

--- a/tests/LINEBot/RichMenuTest.php
+++ b/tests/LINEBot/RichMenuTest.php
@@ -138,6 +138,57 @@ class RichMenuTest extends TestCase
         $this->assertEquals(200, $res->getJSONDecodedBody()['status']);
     }
 
+    public function testSetDefaultRichMenuId()
+    {
+        $mock = function ($testRunner, $httpMethod, $url, $data) {
+            /** @var \PHPUnit\Framework\TestCase $testRunner */
+            $testRunner->assertEquals('POST', $httpMethod);
+            $testRunner->assertEquals('https://api.line.me/v2/bot/user/all/richmenu/123', $url);
+            $testRunner->assertEquals([], $data);
+            return ['status' => 200];
+        };
+        $bot = new LINEBot(new DummyHttpClient($this, $mock), ['channelSecret' => 'CHANNEL-SECRET']);
+        $res = $bot->setDefaultRichMenuId(123);
+
+        $this->assertEquals(200, $res->getHTTPStatus());
+        $this->assertTrue($res->isSucceeded());
+        $this->assertEquals(200, $res->getJSONDecodedBody()['status']);
+    }
+
+    public function testGetDefaultRichMenuId()
+    {
+        $mock = function ($testRunner, $httpMethod, $url, $data) {
+            /** @var \PHPUnit\Framework\TestCase $testRunner */
+            $testRunner->assertEquals('GET', $httpMethod);
+            $testRunner->assertEquals('https://api.line.me/v2/bot/user/all/richmenu', $url);
+            $testRunner->assertEquals([], $data);
+            return ['status' => 200];
+        };
+        $bot = new LINEBot(new DummyHttpClient($this, $mock), ['channelSecret' => 'CHANNEL-SECRET']);
+        $res = $bot->getDefaultRichMenuId();
+
+        $this->assertEquals(200, $res->getHTTPStatus());
+        $this->assertTrue($res->isSucceeded());
+        $this->assertEquals(200, $res->getJSONDecodedBody()['status']);
+    }
+
+    public function testCancelDefaultRichMenuId()
+    {
+        $mock = function ($testRunner, $httpMethod, $url, $data) {
+            /** @var \PHPUnit\Framework\TestCase $testRunner */
+            $testRunner->assertEquals('DELETE', $httpMethod);
+            $testRunner->assertEquals('https://api.line.me/v2/bot/user/all/richmenu', $url);
+            $testRunner->assertEquals([], $data);
+            return ['status' => 200];
+        };
+        $bot = new LINEBot(new DummyHttpClient($this, $mock), ['channelSecret' => 'CHANNEL-SECRET']);
+        $res = $bot->cancelDefaultRichMenuId();
+
+        $this->assertEquals(200, $res->getHTTPStatus());
+        $this->assertTrue($res->isSucceeded());
+        $this->assertEquals(200, $res->getJSONDecodedBody()['status']);
+    }
+
     public function testLinkRichMenu()
     {
         $mock = function ($testRunner, $httpMethod, $url, $data) {


### PR DESCRIPTION
Add default rich menu features.

* https://developers.line.biz/en/docs/messaging-api/using-rich-menus/#get-default-rich-menu-id
* https://developers.line.biz/en/docs/messaging-api/using-rich-menus/#cancel-default-rich-menu
* https://developers.line.biz/en/docs/messaging-api/using-rich-menus/#set-the-default-rich-menu

## ISSUE
Fixes #259