### PR TITLE
Add redelivery object for narrowcast

### DIFF
--- a/src/LINEBot/Narrowcast/Recipient/RedeliveryRecipientBuilder.php
+++ b/src/LINEBot/Narrowcast/Recipient/RedeliveryRecipientBuilder.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace LINE\LINEBot\Narrowcast\Recipient;
+
+/**
+ * A builder class for redelivery recipient
+ *
+ * @package LINE\LINEBot\Narrowcast\Recipient
+ */
+class RedeliveryRecipientBuilder extends RecipientBuilder
+{
+    const TYPE = 'redelivery';
+
+    /** @var string $requestId */
+    private $requestId;
+
+    /**
+     * Set requestId
+     *
+     * @param string $requestId
+     * @return $this
+     */
+    public function setRequestId($requestId)
+    {
+        $this->requestId = $requestId;
+        return $this;
+    }
+
+    /**
+     * Builds recipient
+     *
+     * @return array
+     */
+    public function build()
+    {
+        return [
+            'type' => self::TYPE,
+            'requestId' => $this->requestId
+        ];
+    }
+}
+

--- a/src/LINEBot/Narrowcast/Recipient/RedeliveryRecipientBuilder.php
+++ b/src/LINEBot/Narrowcast/Recipient/RedeliveryRecipientBuilder.php
@@ -54,4 +54,3 @@ class RedeliveryRecipientBuilder extends RecipientBuilder
         ];
     }
 }
-

--- a/tests/LINEBot/NarrowCastTest.php
+++ b/tests/LINEBot/NarrowCastTest.php
@@ -22,6 +22,7 @@ use LINE\LINEBot\Constant\MessageType;
 use LINE\LINEBot\MessageBuilder\TextMessageBuilder;
 use LINE\LINEBot\Narrowcast\Recipient\OperatorRecipientBuilder;
 use LINE\LINEBot\Narrowcast\Recipient\AudienceRecipientBuilder;
+use LINE\LINEBot\Narrowcast\Recipient\RedeliveryRecipientBuilder;
 use LINE\LINEBot\Narrowcast\DemographicFilter\OperatorDemographicFilterBuilder;
 use LINE\LINEBot\Narrowcast\DemographicFilter\GenderDemographicFilterBuilder;
 use LINE\LINEBot\Narrowcast\DemographicFilter\AgeDemographicFilterBuilder;
@@ -85,6 +86,13 @@ class NarrowCastTest extends TestCase
                         ->setNot(
                             AudienceRecipientBuilder::builder()
                                 ->setAudienceGroupId(21234567890)
+                        ),
+                    RedeliveryRecipientBuilder::builder()
+                        ->setRequestId('test request id 1'),
+                    OperatorRecipientBuilder::builder()
+                        ->setNot(
+                            RedeliveryRecipientBuilder::builder()
+                                ->setRequestId('test request id 2')
                         )
                 ]),
             OperatorDemographicFilterBuilder::builder()

--- a/tests/LINEBot/NarrowCastTest.php
+++ b/tests/LINEBot/NarrowCastTest.php
@@ -53,6 +53,17 @@ class NarrowCastTest extends TestCase
                     'audienceGroupId' => 21234567890
                 ]
             ], $data['recipient']['and'][1]);
+            $testRunner->assertEquals([
+                'type' => 'redelivery',
+                'requestId' => 'test request id 1'
+            ], $data['recipient']['and'][2]);
+            $testRunner->assertEquals([
+                'type' => 'operator',
+                'not' => [
+                    'type' => 'redelivery',
+                    'requestId' => 'test request id 2'
+                ]
+            ], $data['recipient']['and'][3]);
             $testRunner->assertEquals('operator', $data['filter']['demographic']['type']);
             $testRunner->assertEquals([
                 'type' => 'gender',


### PR DESCRIPTION
fixes #305 
- [ ] [Support redelivery object for narrowcast](https://developers.line.biz/en/reference/messaging-api/#narrowcast-recipient)