### PR TITLE
Add Activate Audience API

### DIFF
--- a/src/LINEBot.php
+++ b/src/LINEBot.php
@@ -1161,7 +1161,7 @@ class LINEBot
     }
 
     /**
-     * activate the audience
+     * Activate the audience
      *
      * @param int $audienceGroupId The audience ID.
      * @return Response

--- a/src/LINEBot.php
+++ b/src/LINEBot.php
@@ -1161,6 +1161,18 @@ class LINEBot
     }
 
     /**
+     * activate the audience
+     *
+     * @param int $audienceGroupId The audience ID.
+     * @return Response
+     */
+    public function activateAudience($audienceGroupId)
+    {
+        $url = sprintf($this->endpointBase . '/v2/bot/audienceGroup/%s/activate', urlencode($audienceGroupId));
+        return $this->httpClient->put($url, []);
+    }
+
+    /**
      * Get webhook endpoint information
      *
      * @return Response

--- a/tests/LINEBot/ManagementAudienceTest.php
+++ b/tests/LINEBot/ManagementAudienceTest.php
@@ -572,4 +572,43 @@ class ManagementAudienceTest extends TestCase
         $this->assertEquals(200, $res->getHTTPStatus());
         $this->assertTrue($res->isSucceeded());
     }
+
+    public function testActivateAudience202()
+    {
+        $audienceGroupId = "4389303728991";
+        $mock = function ($testRunner, $httpMethod, $url, $data) use ($audienceGroupId) {
+            /** @var \PHPUnit\Framework\TestCase $testRunner */
+            $testRunner->assertEquals('PUT', $httpMethod);
+            $testRunner->assertEquals("https://api.line.me/v2/bot/audienceGroup/{$audienceGroupId}/activate", $url);
+            return [];
+        };
+        $bot = new LINEBot(new DummyHttpClient($this, $mock, 202), ['channelSecret' => 'CHANNEL-SECRET']);
+        $res = $bot->activateAudience($audienceGroupId);
+
+        $this->assertEquals(202, $res->getHTTPStatus());
+        $this->assertTrue($res->isSucceeded());
+    }
+
+    public function testActivateAudience400()
+    {
+        $audienceGroupId = "4389303728991";
+        $mock = function ($testRunner, $httpMethod, $url, $data) use ($audienceGroupId) {
+            /** @var \PHPUnit\Framework\TestCase $testRunner */
+            $testRunner->assertEquals('PUT', $httpMethod);
+            $testRunner->assertEquals("https://api.line.me/v2/bot/audienceGroup/{$audienceGroupId}/activate", $url);
+            return [
+                'status' => 400,
+                'message' => 'ERROR MESSAGE.',
+                'details' => 'ALREADY_ACTIVE',
+            ];
+        };
+        $bot = new LINEBot(new DummyHttpClient($this, $mock, 400), ['channelSecret' => 'CHANNEL-SECRET']);
+        $res = $bot->activateAudience($audienceGroupId);
+
+        $this->assertEquals(400, $res->getHTTPStatus());
+        $this->assertFalse($res->isSucceeded());
+        $data = $res->getJSONDecodedBody();
+        $this->assertEquals('ERROR MESSAGE.', $data['message']);
+        $this->assertEquals('ALREADY_ACTIVE', $data['details']);
+    }
 }

--- a/tests/LINEBot/Util/DummyHttpClient.php
+++ b/tests/LINEBot/Util/DummyHttpClient.php
@@ -20,6 +20,7 @@ namespace LINE\Tests\LINEBot\Util;
 
 use LINE\LINEBot\HTTPClient;
 use LINE\LINEBot\Response;
+use phpDocumentor\Reflection\Types\Integer;
 use PHPUnit\Framework\TestCase;
 
 class DummyHttpClient implements HTTPClient
@@ -28,11 +29,14 @@ class DummyHttpClient implements HTTPClient
     private $testRunner;
     /** @var \Closure */
     private $mock;
+    /** @var int */
+    private $statusCode;
 
-    public function __construct(TestCase $testRunner, \Closure $mock)
+    public function __construct(TestCase $testRunner, \Closure $mock, $statusCode = 200)
     {
         $this->testRunner = $testRunner;
         $this->mock = $mock;
+        $this->statusCode = $statusCode;
     }
 
     /**
@@ -44,7 +48,7 @@ class DummyHttpClient implements HTTPClient
     public function get($url, array $data = [], array $headers = [])
     {
         $ret = call_user_func($this->mock, $this->testRunner, 'GET', $url, is_null($data) ? [] : $data);
-        return new Response(200, json_encode($ret));
+        return new Response($this->statusCode, json_encode($ret));
     }
 
     /**
@@ -56,7 +60,7 @@ class DummyHttpClient implements HTTPClient
     public function post($url, array $data, array $headers = null)
     {
         $ret = call_user_func($this->mock, $this->testRunner, 'POST', $url, $data, $headers);
-        return new Response(200, json_encode($ret));
+        return new Response($this->statusCode, json_encode($ret));
     }
 
     /**
@@ -70,7 +74,7 @@ class DummyHttpClient implements HTTPClient
     public function put($url, array $data, array $headers = null)
     {
         $ret = call_user_func($this->mock, $this->testRunner, 'PUT', $url, $data, $headers);
-        return new Response(200, json_encode($ret));
+        return new Response($this->statusCode, json_encode($ret));
     }
 
     /**
@@ -81,6 +85,6 @@ class DummyHttpClient implements HTTPClient
     public function delete($url, $data = null)
     {
         $ret = call_user_func($this->mock, $this->testRunner, 'DELETE', $url, is_null($data) ? [] : $data);
-        return new Response(200, json_encode($ret));
+        return new Response($this->statusCode, json_encode($ret));
     }
 }

--- a/tests/LINEBot/Util/DummyHttpClient.php
+++ b/tests/LINEBot/Util/DummyHttpClient.php
@@ -20,7 +20,6 @@ namespace LINE\Tests\LINEBot\Util;
 
 use LINE\LINEBot\HTTPClient;
 use LINE\LINEBot\Response;
-use phpDocumentor\Reflection\Types\Integer;
 use PHPUnit\Framework\TestCase;
 
 class DummyHttpClient implements HTTPClient


### PR DESCRIPTION
For [News: You can now use audiences created with LINE Ads and LINE Points Ads](https://developers.line.biz/en/news/2021/01/27/activate-audience-api/)

[activate audience api document](https://developers.line.biz/en/reference/messaging-api/#activate-audience-group)