### PR TITLE
add BaseEvent to toArray method

### DIFF
--- a/src/LINEBot/Event/BaseEvent.php
+++ b/src/LINEBot/Event/BaseEvent.php
@@ -196,11 +196,11 @@ class BaseEvent
     }
 
     /**
-     * Returns the instance as an array.
+     * Returns raw array of the event.
      *
      * @return array
      */
-    public function toArray()
+    public function getEvent()
     {
         return $this->event;
     }

--- a/src/LINEBot/Event/BaseEvent.php
+++ b/src/LINEBot/Event/BaseEvent.php
@@ -194,4 +194,14 @@ class BaseEvent
         # Unknown event
         return null;
     }
+
+    /**
+     * Returns the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->event;
+    }
 }

--- a/src/LINEBot/Event/BaseEvent.php
+++ b/src/LINEBot/Event/BaseEvent.php
@@ -196,7 +196,7 @@ class BaseEvent
     }
 
     /**
-     * Returns raw array of the event.
+     * Returns event
      *
      * @return array
      */

--- a/tests/LINEBot/EventRequestParserTest.php
+++ b/tests/LINEBot/EventRequestParserTest.php
@@ -644,7 +644,7 @@ JSON;
             $this->assertTrue($event->isUserEvent());
             $this->assertEquals('userid', $event->getUserId());
             $this->assertEquals('userid', $event->getEventSourceId());
-            $this->assertEquals($eventArrays[0], $event->toArray());
+            $this->assertEquals($eventArrays[0], $event->getEvent());
             $this->assertInstanceOf('LINE\LINEBot\Event\MessageEvent', $event);
             $this->assertInstanceOf('LINE\LINEBot\Event\MessageEvent\TextMessage', $event);
             /** @var TextMessage $event */

--- a/tests/LINEBot/EventRequestParserTest.php
+++ b/tests/LINEBot/EventRequestParserTest.php
@@ -630,6 +630,7 @@ JSON;
             'Q4tp1jGo39vhlcbd4QiQ/9I+zoJDwGIkPP22wgoOjDI=',
             false
         );
+        $eventArrays = json_decode($this::$json, true)["events"];
 
         $this->assertEquals($destination, 'U0123456789abcdef0123456789abcd');
 
@@ -643,6 +644,7 @@ JSON;
             $this->assertTrue($event->isUserEvent());
             $this->assertEquals('userid', $event->getUserId());
             $this->assertEquals('userid', $event->getEventSourceId());
+            $this->assertEquals($eventArrays[0], $event->toArray());
             $this->assertInstanceOf('LINE\LINEBot\Event\MessageEvent', $event);
             $this->assertInstanceOf('LINE\LINEBot\Event\MessageEvent\TextMessage', $event);
             /** @var TextMessage $event */
@@ -664,6 +666,7 @@ JSON;
             $this->assertEquals('groupid', $event->getGroupId());
             $this->assertEquals('groupid', $event->getEventSourceId());
             $this->assertEquals(null, $event->getUserId());
+            $this->assertEquals($eventArrays[1], $event->toArray());
             $this->assertInstanceOf('LINE\LINEBot\Event\MessageEvent\ImageMessage', $event);
             /** @var ImageMessage $event */
             $this->assertEquals('replytoken', $event->getReplyToken());
@@ -686,6 +689,7 @@ JSON;
             $this->assertTrue($event->isGroupEvent());
             $this->assertEquals('groupid', $event->getGroupId());
             $this->assertEquals('groupid', $event->getEventSourceId());
+            $this->assertEquals($eventArrays[2], $event->toArray());
             $this->assertInstanceOf('LINE\LINEBot\Event\MessageEvent\AudioMessage', $event);
             $this->assertEquals('userid', $event->getUserId());
             /** @var AudioMessage $event */
@@ -707,6 +711,7 @@ JSON;
             $this->assertEquals('roomid', $event->getRoomId());
             $this->assertEquals('roomid', $event->getEventSourceId());
             $this->assertEquals(null, $event->getUserId());
+            $this->assertEquals($eventArrays[3], $event->toArray());
             $this->assertInstanceOf('LINE\LINEBot\Event\MessageEvent\VideoMessage', $event);
             /** @var VideoMessage $event */
             $this->assertEquals('replytoken', $event->getReplyToken());

--- a/tests/LINEBot/EventRequestParserTest.php
+++ b/tests/LINEBot/EventRequestParserTest.php
@@ -666,7 +666,7 @@ JSON;
             $this->assertEquals('groupid', $event->getGroupId());
             $this->assertEquals('groupid', $event->getEventSourceId());
             $this->assertEquals(null, $event->getUserId());
-            $this->assertEquals($eventArrays[1], $event->toArray());
+            $this->assertEquals($eventArrays[1], $event->getEvent());
             $this->assertInstanceOf('LINE\LINEBot\Event\MessageEvent\ImageMessage', $event);
             /** @var ImageMessage $event */
             $this->assertEquals('replytoken', $event->getReplyToken());
@@ -689,7 +689,7 @@ JSON;
             $this->assertTrue($event->isGroupEvent());
             $this->assertEquals('groupid', $event->getGroupId());
             $this->assertEquals('groupid', $event->getEventSourceId());
-            $this->assertEquals($eventArrays[2], $event->toArray());
+            $this->assertEquals($eventArrays[2], $event->getEvent());
             $this->assertInstanceOf('LINE\LINEBot\Event\MessageEvent\AudioMessage', $event);
             $this->assertEquals('userid', $event->getUserId());
             /** @var AudioMessage $event */
@@ -711,7 +711,7 @@ JSON;
             $this->assertEquals('roomid', $event->getRoomId());
             $this->assertEquals('roomid', $event->getEventSourceId());
             $this->assertEquals(null, $event->getUserId());
-            $this->assertEquals($eventArrays[3], $event->toArray());
+            $this->assertEquals($eventArrays[3], $event->getEvent());
             $this->assertInstanceOf('LINE\LINEBot\Event\MessageEvent\VideoMessage', $event);
             /** @var VideoMessage $event */
             $this->assertEquals('replytoken', $event->getReplyToken());


### PR DESCRIPTION
In the case of storing received events, I have to make store methods for each of event classes or parse received event json manually.
The toArray method provides us to access the original event array, so we can easily save it.