### PR TITLE
Add PHPStan Static Analysis Tool and fix issues from level 1 to level 5

### DIFF
--- a/.github/workflows/php-checks.yml
+++ b/.github/workflows/php-checks.yml
@@ -1,0 +1,58 @@
+name: PHP Checks
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    name: Run checks on PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4]
+        include:
+          - php: 7.4
+            analysis: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-${{ matrix.php }}-
+
+      - name: Install dependencies with Composer
+        uses: ramsey/composer-install@v1
+        
+      - name: Check copyrights
+        if: matrix.analysis
+        run: bash devtool/check_copyright.sh
+
+      - name: Check code style with PHP_CodeSniffer
+        if: matrix.analysis
+        run: vendor/bin/phpcs --standard=PSR2 src tests examples/EchoBot/src examples/EchoBot/public examples/KitchenSink/src examples/KitchenSink/public
+
+      - name: Check with PHP Mess Detector 
+        if: matrix.analysis
+        run: vendor/bin/phpmd --ignore-violations-on-exit src,examples/EchoBot/src,examples/EchoBot/public,examples/KitchenSink/src,examples/KitchenSink/public text phpmd.xml
+
+      - name: Check with PHPStan
+        if: matrix.analysis
+        run: bash devtool/check_phpstan.sh
+
+      - name: Run unit tests
+        run: vendor/bin/phpunit --debug tests

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ phpmd:
 	composer md
 
 phpstan:
-	composer stan
+	devtool/check_phpstan.sh
 
 copyright:
 	devtool/check_copyright.sh

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,13 @@ phpcs:
 phpmd:
 	composer md
 
+phpstan:
+	composer stan
+
 copyright:
 	devtool/check_copyright.sh
 
-check: test copyright phpcs phpmd
+check: test copyright phpcs phpmd phpstan
 
 clean:
 	rm -rf vendor composer.lock

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
     "phpunit/phpunit": "^4.8.36||^5||^6||^7",
     "phpmd/phpmd": "~2.9",
     "squizlabs/php_codesniffer": "~3.5",
-    "orchestra/testbench": "*"
+    "orchestra/testbench": "*",
+    "phpstan/phpstan": "^0.12.90"
   },
   "suggest": {
     "apigen/apigen": "Install with roave/better-reflection:dev-master to generate docs",
@@ -61,7 +62,8 @@
     "test": "phpunit --debug tests",
     "doc": "apigen generate src --destination docs",
     "cs": "phpcs --standard=PSR2 src tests examples/EchoBot/src examples/EchoBot/public examples/KitchenSink/src examples/KitchenSink/public",
-    "md": "phpmd --ignore-violations-on-exit src,examples/EchoBot/src,examples/EchoBot/public,examples/KitchenSink/src,examples/KitchenSink/public text phpmd.xml"
+    "md": "phpmd --ignore-violations-on-exit src,examples/EchoBot/src,examples/EchoBot/public,examples/KitchenSink/src,examples/KitchenSink/public text phpmd.xml",
+    "stan": "phpstan analyse"
   },
   "extra": {
     "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,7 @@
     "phpunit/phpunit": "^4.8.36||^5||^6||^7",
     "phpmd/phpmd": "~2.9",
     "squizlabs/php_codesniffer": "~3.5",
-    "orchestra/testbench": "*",
-    "phpstan/phpstan": "^0.12.90"
+    "orchestra/testbench": "*"
   },
   "suggest": {
     "apigen/apigen": "Install with roave/better-reflection:dev-master to generate docs",
@@ -63,7 +62,7 @@
     "doc": "apigen generate src --destination docs",
     "cs": "phpcs --standard=PSR2 src tests examples/EchoBot/src examples/EchoBot/public examples/KitchenSink/src examples/KitchenSink/public",
     "md": "phpmd --ignore-violations-on-exit src,examples/EchoBot/src,examples/EchoBot/public,examples/KitchenSink/src,examples/KitchenSink/public text phpmd.xml",
-    "stan": "phpstan analyse"
+    "stan": "devtool/check_phpstan.sh"
   },
   "extra": {
     "laravel": {

--- a/devtool/check_phpstan.sh
+++ b/devtool/check_phpstan.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Workaround as PHPStan requires PHP version >= 7.1
+
+composer require --quiet --no-interaction --dev phpstan/phpstan
+vendor/bin/phpstan analyse
+composer remove --quiet --no-interaction --dev phpstan/phpstan

--- a/line-bot-sdk-tiny/LINEBotTiny.php
+++ b/line-bot-sdk-tiny/LINEBotTiny.php
@@ -26,6 +26,11 @@
 if (!function_exists('hash_equals')) {
     defined('USE_MB_STRING') or define('USE_MB_STRING', function_exists('mb_strlen'));
 
+    /**
+     * @param string $knownString
+     * @param string $userString
+     * @return bool
+     */
     function hash_equals($knownString, $userString)
     {
         $strlen = function ($string) {
@@ -53,15 +58,24 @@ if (!function_exists('hash_equals')) {
 
 class LINEBotTiny
 {
+    /** @var string */
     private $channelAccessToken;
+    /** @var string */
     private $channelSecret;
 
+    /**
+     * @param string $channelAccessToken
+     * @param string $channelSecret
+     */
     public function __construct($channelAccessToken, $channelSecret)
     {
         $this->channelAccessToken = $channelAccessToken;
         $this->channelSecret = $channelSecret;
     }
 
+    /**
+     * @return mixed
+     */
     public function parseEvents()
     {
         if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
@@ -72,7 +86,7 @@ class LINEBotTiny
 
         $entityBody = file_get_contents('php://input');
 
-        if (strlen($entityBody) === 0) {
+        if ($entityBody === false || strlen($entityBody) === 0) {
             http_response_code(400);
             error_log('Missing request body');
             exit();
@@ -93,6 +107,10 @@ class LINEBotTiny
         return $data['events'];
     }
 
+    /**
+     * @param array<string, mixed> $message
+     * @return void
+     */
     public function replyMessage($message)
     {
         $header = array(
@@ -115,6 +133,10 @@ class LINEBotTiny
         }
     }
 
+    /**
+     * @param string $body
+     * @return string
+     */
     private function sign($body)
     {
         $hash = hash_hmac('sha256', $body, $this->channelSecret, true);

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-  level: 4
+  level: 5
   paths:
     - src
   ignoreErrors:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,10 @@
+parameters:
+  level: 1
+  paths:
+    - src
+  ignoreErrors:
+    # A known bug in phpstan: https://github.com/phpstan/phpstan/issues/5252
+    - message: '#Unsafe usage of new static\(\).#'
+      paths:
+        - src\LINEBot\Narrowcast\DemographicFilter\DemographicFilterBuilder.php
+        - src\LINEBot\Narrowcast\Recipient\RecipientBuilder.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,7 @@
 parameters:
   level: 5
   paths:
+    - line-bot-sdk-tiny
     - src
   ignoreErrors:
     # A known bug in phpstan: https://github.com/phpstan/phpstan/issues/5252

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-  level: 1
+  level: 2
   paths:
     - src
   ignoreErrors:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-  level: 3
+  level: 4
   paths:
     - src
   ignoreErrors:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-  level: 2
+  level: 3
   paths:
     - src
   ignoreErrors:

--- a/src/LINEBot.php
+++ b/src/LINEBot.php
@@ -1115,7 +1115,10 @@ class LINEBot
      */
     public function renameAudience($audienceGroupId, $description)
     {
-        $url = sprintf($this->endpointBase . '/v2/bot/audienceGroup/%s/updateDescription', urlencode(strval($audienceGroupId)));
+        $url = sprintf(
+            $this->endpointBase . '/v2/bot/audienceGroup/%s/updateDescription',
+            urlencode(strval($audienceGroupId))
+        );
         return $this->httpClient->put($url, ['description' => $description]);
     }
 

--- a/src/LINEBot.php
+++ b/src/LINEBot.php
@@ -213,8 +213,8 @@ class LINEBot
             $extra = array_slice($args, 2);
         }
 
-        /** @var TextMessageBuilder $textMessageBuilder */
         $ref = new ReflectionClass('LINE\LINEBot\MessageBuilder\TextMessageBuilder');
+        /** @var TextMessageBuilder $textMessageBuilder */
         $textMessageBuilder = $ref->newInstanceArgs(array_merge([$text], $extra));
 
         return $this->replyMessage($replyToken, $textMessageBuilder);
@@ -918,7 +918,7 @@ class LINEBot
      * @param MessageBuilder $messageBuilder
      * @param RecipientBuilder|null $recipientBuilder
      * @param DemographicFilterBuilder|null $demographicFilterBuilder
-     * @param int|null $limit
+     * @param int|null $max
      * @param string|null $retryKey UUID(example: 123e4567-e89b-12d3-a456-426614174000) or Not needed retry(=null)
      * @return Response
      */

--- a/src/LINEBot.php
+++ b/src/LINEBot.php
@@ -1115,7 +1115,7 @@ class LINEBot
      */
     public function renameAudience($audienceGroupId, $description)
     {
-        $url = sprintf($this->endpointBase . '/v2/bot/audienceGroup/%s/updateDescription', urlencode($audienceGroupId));
+        $url = sprintf($this->endpointBase . '/v2/bot/audienceGroup/%s/updateDescription', urlencode(strval($audienceGroupId)));
         return $this->httpClient->put($url, ['description' => $description]);
     }
 
@@ -1127,7 +1127,7 @@ class LINEBot
      */
     public function deleteAudience($audienceGroupId)
     {
-        $url = sprintf($this->endpointBase . '/v2/bot/audienceGroup/%s', urlencode($audienceGroupId));
+        $url = sprintf($this->endpointBase . '/v2/bot/audienceGroup/%s', urlencode(strval($audienceGroupId)));
         return $this->httpClient->delete($url);
     }
 
@@ -1139,7 +1139,7 @@ class LINEBot
      */
     public function getAudience($audienceGroupId)
     {
-        $url = sprintf($this->endpointBase . '/v2/bot/audienceGroup/%s', urlencode($audienceGroupId));
+        $url = sprintf($this->endpointBase . '/v2/bot/audienceGroup/%s', urlencode(strval($audienceGroupId)));
         return $this->httpClient->get($url);
     }
 
@@ -1212,7 +1212,7 @@ class LINEBot
      */
     public function activateAudience($audienceGroupId)
     {
-        $url = sprintf($this->endpointBase . '/v2/bot/audienceGroup/%s/activate', urlencode($audienceGroupId));
+        $url = sprintf($this->endpointBase . '/v2/bot/audienceGroup/%s/activate', urlencode(strval($audienceGroupId)));
         return $this->httpClient->put($url, []);
     }
 

--- a/src/LINEBot/Event/Parser/EventRequestParser.php
+++ b/src/LINEBot/Event/Parser/EventRequestParser.php
@@ -63,7 +63,7 @@ class EventRequestParser
      */
     public static function parseEventRequest($body, $channelSecret, $signature, $eventsOnly = true)
     {
-        if (!isset($signature)) {
+        if (trim($signature) === '') {
             throw new InvalidSignatureException('Request does not contain signature');
         }
 

--- a/src/LINEBot/HTTPClient/Curl.php
+++ b/src/LINEBot/HTTPClient/Curl.php
@@ -53,7 +53,7 @@ class Curl
     /**
      * Perform a cURL session
      *
-     * @return bool Returns TRUE on success or FALSE on failure. However, if the CURLOPT_RETURNTRANSFER
+     * @return bool|string Returns TRUE on success or FALSE on failure. However, if the CURLOPT_RETURNTRANSFER
      * option is set, it will return the result on success, FALSE on failure.
      */
     public function exec()

--- a/src/LINEBot/HTTPClient/CurlHTTPClient.php
+++ b/src/LINEBot/HTTPClient/CurlHTTPClient.php
@@ -195,7 +195,7 @@ class CurlHTTPClient implements HTTPClient
      * @param string $method
      * @param string $url
      * @param array $additionalHeader
-     * @param string|null $reqBody
+     * @param string|array|null $reqBody
      * @return Response
      * @throws CurlExecutionException
      */

--- a/src/LINEBot/HTTPClient/CurlHTTPClient.php
+++ b/src/LINEBot/HTTPClient/CurlHTTPClient.php
@@ -137,7 +137,7 @@ class CurlHTTPClient implements HTTPClient
     /**
      * @param string $method
      * @param array $headers
-     * @param string|null $reqBody
+     * @param array|string|null $reqBody
      * @return array cUrl options
      */
     private function getOptions($method, $headers, $reqBody)

--- a/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/BoxComponentBuilder.php
+++ b/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/BoxComponentBuilder.php
@@ -18,16 +18,17 @@
 
 namespace LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder;
 
-use LINE\LINEBot\TemplateActionBuilder;
-use LINE\LINEBot\Constant\Flex\ComponentLayout;
-use LINE\LINEBot\Constant\Flex\ComponentMargin;
-use LINE\LINEBot\Constant\Flex\ComponentSpacing;
-use LINE\LINEBot\Constant\Flex\ComponentType;
-use LINE\LINEBot\Constant\Flex\ComponentPosition;
-use LINE\LINEBot\Constant\Flex\ComponentJustifyContent;
 use LINE\LINEBot\Constant\Flex\ComponentAlignItems;
 use LINE\LINEBot\Constant\Flex\ComponentBackgroundType;
+use LINE\LINEBot\Constant\Flex\ComponentBorderWidth;
+use LINE\LINEBot\Constant\Flex\ComponentJustifyContent;
+use LINE\LINEBot\Constant\Flex\ComponentLayout;
+use LINE\LINEBot\Constant\Flex\ComponentMargin;
+use LINE\LINEBot\Constant\Flex\ComponentPosition;
+use LINE\LINEBot\Constant\Flex\ComponentSpacing;
+use LINE\LINEBot\Constant\Flex\ComponentType;
 use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder;
+use LINE\LINEBot\TemplateActionBuilder;
 use LINE\LINEBot\Util\BuildUtil;
 
 /**

--- a/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/BoxComponentBuilder.php
+++ b/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/BoxComponentBuilder.php
@@ -110,8 +110,8 @@ class BoxComponentBuilder implements ComponentBuilder
     /**
      * BoxComponentBuilder constructor.
      *
-     * @param ComponentLayout|string $layout
-     * @param ComponentBuilder[] $componentBuilders
+     * @param ComponentLayout|string|null $layout
+     * @param ComponentBuilder[]|null $componentBuilders
      * @param int|null $flex
      * @param ComponentSpacing|string|null $spacing
      * @param ComponentMargin|null $margin

--- a/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/ButtonComponentBuilder.php
+++ b/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/ButtonComponentBuilder.php
@@ -72,7 +72,7 @@ class ButtonComponentBuilder implements ComponentBuilder
     /**
      * ButtonComponentBuilder constructor.
      *
-     * @param TemplateActionBuilder $actionBuilder
+     * @param TemplateActionBuilder|null $actionBuilder
      * @param int|null $flex
      * @param ComponentMargin|null $margin
      * @param ComponentButtonHeight|null $height

--- a/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/ButtonComponentBuilder.php
+++ b/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/ButtonComponentBuilder.php
@@ -18,14 +18,16 @@
 
 namespace LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder;
 
-use LINE\LINEBot\TemplateActionBuilder;
+use LINE\LINEBot\Constant\Flex\ComponentAdjustMode;
 use LINE\LINEBot\Constant\Flex\ComponentButtonHeight;
 use LINE\LINEBot\Constant\Flex\ComponentButtonStyle;
 use LINE\LINEBot\Constant\Flex\ComponentGravity;
 use LINE\LINEBot\Constant\Flex\ComponentMargin;
+use LINE\LINEBot\Constant\Flex\ComponentPosition;
+use LINE\LINEBot\Constant\Flex\ComponentSpacing;
 use LINE\LINEBot\Constant\Flex\ComponentType;
-use LINE\LINEBot\Constant\Flex\ComponentAdjustMode;
 use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder;
+use LINE\LINEBot\TemplateActionBuilder;
 use LINE\LINEBot\Util\BuildUtil;
 
 /**

--- a/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/IconComponentBuilder.php
+++ b/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/IconComponentBuilder.php
@@ -60,7 +60,7 @@ class IconComponentBuilder implements ComponentBuilder
     /**
      * IconComponentBuilder constructor.
      *
-     * @param string $url
+     * @param string|null $url
      * @param ComponentMargin|null $margin
      * @param ComponentIconSize|string|null $size
      * @param ComponentIconAspectRatio|null $aspectRatio

--- a/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/IconComponentBuilder.php
+++ b/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/IconComponentBuilder.php
@@ -21,6 +21,8 @@ namespace LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder;
 use LINE\LINEBot\Constant\Flex\ComponentIconAspectRatio;
 use LINE\LINEBot\Constant\Flex\ComponentIconSize;
 use LINE\LINEBot\Constant\Flex\ComponentMargin;
+use LINE\LINEBot\Constant\Flex\ComponentPosition;
+use LINE\LINEBot\Constant\Flex\ComponentSpacing;
 use LINE\LINEBot\Constant\Flex\ComponentType;
 use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder;
 use LINE\LINEBot\Util\BuildUtil;

--- a/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/ImageComponentBuilder.php
+++ b/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/ImageComponentBuilder.php
@@ -79,7 +79,7 @@ class ImageComponentBuilder implements ComponentBuilder
     /**
      * ImageComponentBuilder constructor.
      *
-     * @param string $url
+     * @param string|null $url
      * @param int|null $flex
      * @param ComponentMargin|null $margin
      * @param ComponentAlign|null $align

--- a/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/ImageComponentBuilder.php
+++ b/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/ImageComponentBuilder.php
@@ -18,15 +18,17 @@
 
 namespace LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder;
 
-use LINE\LINEBot\TemplateActionBuilder;
 use LINE\LINEBot\Constant\Flex\ComponentAlign;
 use LINE\LINEBot\Constant\Flex\ComponentGravity;
 use LINE\LINEBot\Constant\Flex\ComponentImageAspectMode;
 use LINE\LINEBot\Constant\Flex\ComponentImageAspectRatio;
 use LINE\LINEBot\Constant\Flex\ComponentImageSize;
 use LINE\LINEBot\Constant\Flex\ComponentMargin;
+use LINE\LINEBot\Constant\Flex\ComponentPosition;
+use LINE\LINEBot\Constant\Flex\ComponentSpacing;
 use LINE\LINEBot\Constant\Flex\ComponentType;
 use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder;
+use LINE\LINEBot\TemplateActionBuilder;
 use LINE\LINEBot\Util\BuildUtil;
 
 /**

--- a/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/SpanComponentBuilder.php
+++ b/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/SpanComponentBuilder.php
@@ -64,9 +64,9 @@ class SpanComponentBuilder implements ComponentBuilder
     }
 
     /**
-     * Create empty TextComponentBuilder.
+     * Create empty SpanComponentBuilder.
      *
-     * @return TextComponentBuilder
+     * @return SpanComponentBuilder
      */
     public static function builder()
     {
@@ -77,7 +77,7 @@ class SpanComponentBuilder implements ComponentBuilder
      * Set text.
      *
      * @param string $text
-     * @return TextComponentBuilder
+     * @return SpanComponentBuilder
      */
     public function setText($text)
     {
@@ -94,7 +94,7 @@ class SpanComponentBuilder implements ComponentBuilder
      * keyword: xxs (defined in ComponentFontSize)
      *
      * @param ComponentFontSize|string|null $size
-     * @return TextComponentBuilder
+     * @return SpanComponentBuilder
      */
     public function setSize($size)
     {
@@ -106,7 +106,7 @@ class SpanComponentBuilder implements ComponentBuilder
      * Set weight.
      *
      * @param ComponentFontWeight|string|null $weight
-     * @return TextComponentBuilder
+     * @return SpanComponentBuilder
      */
     public function setWeight($weight)
     {
@@ -118,7 +118,7 @@ class SpanComponentBuilder implements ComponentBuilder
      * Set color.
      *
      * @param string|null $color
-     * @return TextComponentBuilder
+     * @return SpanComponentBuilder
      */
     public function setColor($color)
     {
@@ -129,8 +129,8 @@ class SpanComponentBuilder implements ComponentBuilder
     /**
      * Set style.
      *
-     * @param string|null $style
-     * @return TextComponentBuilder
+     * @param ComponentTextStyle|string|null $style
+     * @return SpanComponentBuilder
      */
     public function setStyle($style)
     {
@@ -141,8 +141,8 @@ class SpanComponentBuilder implements ComponentBuilder
     /**
      * Set decoration.
      *
-     * @param string|null $decoration
-     * @return TextComponentBuilder
+     * @param ComponentTextDecoration|string|null $decoration
+     * @return SpanComponentBuilder
      */
     public function setDecoration($decoration)
     {

--- a/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/TextComponentBuilder.php
+++ b/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/TextComponentBuilder.php
@@ -90,7 +90,7 @@ class TextComponentBuilder implements ComponentBuilder
     /**
      * TextComponentBuilder constructor.
      *
-     * @param string $text
+     * @param string|null $text
      * @param int|null $flex
      * @param ComponentMargin|null $margin
      * @param ComponentFontSize|null $size

--- a/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/TextComponentBuilder.php
+++ b/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/TextComponentBuilder.php
@@ -266,7 +266,7 @@ class TextComponentBuilder implements ComponentBuilder
     /**
      * Set style.
      *
-     * @param string|null $style
+     * @param ComponentTextStyle|string|null $style
      * @return TextComponentBuilder
      */
     public function setStyle($style)
@@ -278,7 +278,7 @@ class TextComponentBuilder implements ComponentBuilder
     /**
      * Set decoration.
      *
-     * @param string|null $decoration
+     * @param ComponentTextDecoration|string|null $decoration
      * @return TextComponentBuilder
      */
     public function setDecoration($decoration)

--- a/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/TextComponentBuilder.php
+++ b/src/LINEBot/MessageBuilder/Flex/ComponentBuilder/TextComponentBuilder.php
@@ -18,17 +18,19 @@
 
 namespace LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder;
 
-use LINE\LINEBot\TemplateActionBuilder;
+use LINE\LINEBot\Constant\Flex\ComponentAdjustMode;
 use LINE\LINEBot\Constant\Flex\ComponentAlign;
 use LINE\LINEBot\Constant\Flex\ComponentFontSize;
 use LINE\LINEBot\Constant\Flex\ComponentFontWeight;
 use LINE\LINEBot\Constant\Flex\ComponentGravity;
 use LINE\LINEBot\Constant\Flex\ComponentMargin;
-use LINE\LINEBot\Constant\Flex\ComponentType;
+use LINE\LINEBot\Constant\Flex\ComponentPosition;
+use LINE\LINEBot\Constant\Flex\ComponentSpacing;
 use LINE\LINEBot\Constant\Flex\ComponentTextDecoration;
 use LINE\LINEBot\Constant\Flex\ComponentTextStyle;
-use LINE\LINEBot\Constant\Flex\ComponentAdjustMode;
+use LINE\LINEBot\Constant\Flex\ComponentType;
 use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder;
+use LINE\LINEBot\TemplateActionBuilder;
 use LINE\LINEBot\Util\BuildUtil;
 
 /**

--- a/src/LINEBot/MessageBuilder/Flex/ContainerBuilder/BubbleContainerBuilder.php
+++ b/src/LINEBot/MessageBuilder/Flex/ContainerBuilder/BubbleContainerBuilder.php
@@ -18,13 +18,14 @@
 
 namespace LINE\LINEBot\MessageBuilder\Flex\ContainerBuilder;
 
+use LINE\LINEBot\Constant\Flex\BubbleContainerSize;
 use LINE\LINEBot\Constant\Flex\ContainerDirection;
 use LINE\LINEBot\Constant\Flex\ContainerType;
-use LINE\LINEBot\Constant\Flex\BubleContainerSize;
-use LINE\LINEBot\MessageBuilder\Flex\ContainerBuilder;
 use LINE\LINEBot\MessageBuilder\Flex\BubbleStylesBuilder;
-use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder\BoxComponentBuilder;
 use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder;
+use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder\BoxComponentBuilder;
+use LINE\LINEBot\MessageBuilder\Flex\ContainerBuilder;
+use LINE\LINEBot\TemplateActionBuilder;
 use LINE\LINEBot\Util\BuildUtil;
 
 /**
@@ -46,7 +47,7 @@ class BubbleContainerBuilder implements ContainerBuilder
     private $footerComponentBuilder;
     /** @var BubbleStylesBuilder */
     private $stylesBuilder;
-    /** @var BubleContainerSize */
+    /** @var BubbleContainerSize */
     private $size;
     /** @var TemplateActionBuilder */
     private $actionBuilder;
@@ -63,7 +64,7 @@ class BubbleContainerBuilder implements ContainerBuilder
      * @param BoxComponentBuilder|null $bodyComponentBuilder
      * @param BoxComponentBuilder|null $footerComponentBuilder
      * @param BubbleStylesBuilder|null $stylesBuilder
-     * @param BubleContainerSize|null $size
+     * @param BubbleContainerSize|null $size
      */
     public function __construct(
         $direction = null,
@@ -97,7 +98,7 @@ class BubbleContainerBuilder implements ContainerBuilder
      * Set size.
      * default: mega
      *
-     * @param BubleContainerSize|string|null $direction
+     * @param BubbleContainerSize|string|null $size
      * @return BubbleContainerBuilder
      */
     public function setSize($size)

--- a/src/LINEBot/MessageBuilder/Flex/ContainerBuilder/CarouselContainerBuilder.php
+++ b/src/LINEBot/MessageBuilder/Flex/ContainerBuilder/CarouselContainerBuilder.php
@@ -37,7 +37,7 @@ class CarouselContainerBuilder implements ContainerBuilder
     /**
      * AreaBuilder constructor.
      *
-     * @param BubbleContainerBuilder[] $containerBuilders
+     * @param BubbleContainerBuilder[]|null $containerBuilders
      */
     public function __construct($containerBuilders)
     {

--- a/src/LINEBot/MessageBuilder/FlexMessageBuilder.php
+++ b/src/LINEBot/MessageBuilder/FlexMessageBuilder.php
@@ -49,8 +49,8 @@ class FlexMessageBuilder implements MessageBuilder
     /**
      * FlexMessageBuilder constructor.
      *
-     * @param string $altText
-     * @param ContainerBuilder $containerBuilder
+     * @param string|null $altText
+     * @param ContainerBuilder|null $containerBuilder
      * @param QuickReplyBuilder|null $quickReply
      * @param SenderBuilder|null $sender
      */

--- a/src/LINEBot/MessageBuilder/Imagemap/VideoBuilder.php
+++ b/src/LINEBot/MessageBuilder/Imagemap/VideoBuilder.php
@@ -41,8 +41,8 @@ class VideoBuilder
      *
      * @param string $originalContentUrl
      * @param string $previewImageUrl
-     * @param AreaBuilder $area
-     * @param ExternalLinkBuilder|null $externalLink
+     * @param AreaBuilder $areaBuilder
+     * @param ExternalLinkBuilder|null $externalLinkBuilder
      */
     public function __construct(
         $originalContentUrl,

--- a/src/LINEBot/MessageBuilder/TemplateBuilder/ButtonTemplateBuilder.php
+++ b/src/LINEBot/MessageBuilder/TemplateBuilder/ButtonTemplateBuilder.php
@@ -55,7 +55,7 @@ class ButtonTemplateBuilder implements TemplateBuilder
     private $template;
 
     /**
-     * @var TemplateActionBuilder
+     * @var TemplateActionBuilder|null
      */
     private $defaultAction;
 

--- a/src/LINEBot/MessageBuilder/Text/EmojiBuilder.php
+++ b/src/LINEBot/MessageBuilder/Text/EmojiBuilder.php
@@ -35,7 +35,7 @@ class EmojiBuilder
     /**
      * EmojiBuilder constructor.
      *
-     * @param array $emojis The specified position must correspond to a $.
+     * @param int $index The specified position must correspond to a $.
      * @param string $productId Product ID for a set of LINE emoji.
      * @param string $emojiId ID for a LINE emoji inside a set.
      */

--- a/src/LINEBot/Narrowcast/DemographicFilter/DemographicFilterBuilder.php
+++ b/src/LINEBot/Narrowcast/DemographicFilter/DemographicFilterBuilder.php
@@ -38,7 +38,6 @@ abstract class DemographicFilterBuilder
      */
     public static function builder()
     {
-        $class = \get_called_class();
-        return new $class();
+        return new static();
     }
 }

--- a/src/LINEBot/Narrowcast/DemographicFilter/OperatorDemographicFilterBuilder.php
+++ b/src/LINEBot/Narrowcast/DemographicFilter/OperatorDemographicFilterBuilder.php
@@ -29,7 +29,7 @@ class OperatorDemographicFilterBuilder extends DemographicFilterBuilder
     /** @var string $operator */
     private $operator;
 
-    /** @var DemographicFilterBuilder[] $children */
+    /** @var array<DemographicFilterBuilder|DemographicFilterBuilder[]> $children */
     private $children = [];
 
     /**

--- a/src/LINEBot/Narrowcast/Recipient/OperatorRecipientBuilder.php
+++ b/src/LINEBot/Narrowcast/Recipient/OperatorRecipientBuilder.php
@@ -29,7 +29,7 @@ class OperatorRecipientBuilder extends RecipientBuilder
     /** @var string $operator */
     private $operator;
 
-    /** @var RecipientBuilder[] $children */
+    /** @var array<RecipientBuilder|RecipientBuilder[]> $children */
     private $children = [];
 
     /**

--- a/src/LINEBot/Narrowcast/Recipient/RecipientBuilder.php
+++ b/src/LINEBot/Narrowcast/Recipient/RecipientBuilder.php
@@ -38,7 +38,6 @@ abstract class RecipientBuilder
      */
     public static function builder()
     {
-        $class = \get_called_class();
-        return new $class();
+        return new static();
     }
 }

--- a/src/LINEBot/SenderBuilder/SenderMessageBuilder.php
+++ b/src/LINEBot/SenderBuilder/SenderMessageBuilder.php
@@ -30,7 +30,7 @@ class SenderMessageBuilder implements SenderBuilder
     private $name;
     /** @var string|null */
     private $iconUrl;
-    /** @var array */
+    /** @var array|null */
     private $sender;
 
     /**

--- a/src/LINEBot/SignatureValidator.php
+++ b/src/LINEBot/SignatureValidator.php
@@ -38,7 +38,7 @@ class SignatureValidator
      */
     public static function validateSignature($body, $channelSecret, $signature)
     {
-        if (!isset($signature)) {
+        if (trim($signature) === '') {
             throw new InvalidSignatureException('Signature must not be empty');
         }
 

--- a/src/LINEBot/TemplateActionBuilder/DatetimePickerTemplateActionBuilder.php
+++ b/src/LINEBot/TemplateActionBuilder/DatetimePickerTemplateActionBuilder.php
@@ -56,10 +56,10 @@ class DatetimePickerTemplateActionBuilder implements TemplateActionBuilder
      * date: Pick date
      * time: Pick time
      * datetime: Pick date and time
-     * @param string initial Initial value of date or time
-     * @param string max Largest date or time value that can be selected.
+     * @param string $initial Initial value of date or time
+     * @param string $max Largest date or time value that can be selected.
      * Must be greater than the min value.
-     * @param string min Smallest date or time value that can be selected.
+     * @param string $min Smallest date or time value that can be selected.
      * Must be less than the max value.
      */
     public function __construct($label, $data, $mode, $initial = null, $max = null, $min = null)

--- a/src/LINEBot/TemplateActionBuilder/UriTemplateActionBuilder.php
+++ b/src/LINEBot/TemplateActionBuilder/UriTemplateActionBuilder.php
@@ -34,7 +34,7 @@ class UriTemplateActionBuilder implements TemplateActionBuilder
     private $label;
     /** @var string */
     private $uri;
-    /** @var AltUriBuilder */
+    /** @var AltUriBuilder|null */
     private $altUri;
 
     /**


### PR DESCRIPTION
Add PHPStan to development dependencies and Travis CI.
Fixed all issues from level 1 to level 5 (the strictest currently is level 8).

Having PHPStan forcing stricter type which reduce errors we make, also it helps IDE like PHPStorm to provide better auto-completion prompts. Also when we decided to deprecate PHP 5 and even PHP 7, it eases the works to make the code strictly typed.