### PR TITLE
Add CI via GitHub Actions

### DIFF
--- a/.github/workflows/php-checks.yml
+++ b/.github/workflows/php-checks.yml
@@ -9,13 +9,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4]
         include:
-          - php: 5.6
-            composer-options: "--ignore-platform-reqs"
-          - php: 7.0
-            composer-options: "--ignore-platform-reqs"
-          - php: 8.0
+          - php: 7.4
             analysis: true
 
     steps:
@@ -41,8 +37,10 @@ jobs:
 
       - name: Install dependencies with Composer
         uses: ramsey/composer-install@v1
-        with:
-          composer-options: "${{ matrix.composer-options }}"
+        
+      - name: Check copyrights
+        if: matrix.analysis
+        run: bash devtool/check_copyright.sh
 
       - name: Check code style with PHP_CodeSniffer
         if: matrix.analysis
@@ -52,9 +50,9 @@ jobs:
         if: matrix.analysis
         run: vendor/bin/phpmd --ignore-violations-on-exit src,examples/EchoBot/src,examples/EchoBot/public,examples/KitchenSink/src,examples/KitchenSink/public text phpmd.xml
 
-      # - name: Check with PHPStan
-      #   if: matrix.analysis
-      #   run: vendor/bin/phpstan analyse
+      - name: Check with PHPStan
+        if: matrix.analysis
+        run: devtool/check_phpstan.sh
 
       - name: Run unit tests
         run: vendor/bin/phpunit --debug tests

--- a/.github/workflows/php-checks.yml
+++ b/.github/workflows/php-checks.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Check with PHPStan
         if: matrix.analysis
-        run: devtool/check_phpstan.sh
+        run: bash devtool/check_phpstan.sh
 
       - name: Run unit tests
         run: vendor/bin/phpunit --debug tests

--- a/.github/workflows/php-checks.yml
+++ b/.github/workflows/php-checks.yml
@@ -1,0 +1,54 @@
+name: PHP Checks
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    name: Run checks on PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0]
+        include:
+          - php: 8.0
+            analysis: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-${{ matrix.php }}-
+
+      - name: Install dependencies with Composer
+        uses: ramsey/composer-install@v1
+
+      - name: Check code style with PHP_CodeSniffer
+        if: matrix.analysis
+        run: vendor/bin/phpcs --standard=PSR2 src tests examples/EchoBot/src examples/EchoBot/public examples/KitchenSink/src examples/KitchenSink/public
+
+      - name: Check with PHP Mess Detector 
+        if: matrix.analysis
+        run: vendor/bin/phpmd --ignore-violations-on-exit src,examples/EchoBot/src,examples/EchoBot/public,examples/KitchenSink/src,examples/KitchenSink/public text phpmd.xml
+
+      # - name: Check with PHPStan
+      #   if: matrix.analysis
+      #   run: vendor/bin/phpstan analyse
+
+      - name: Run unit tests
+        run: vendor/bin/phpunit --debug tests

--- a/.github/workflows/php-checks.yml
+++ b/.github/workflows/php-checks.yml
@@ -11,6 +11,10 @@ jobs:
       matrix:
         php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0]
         include:
+          - php: 5.6
+            composer-options: "--ignore-platform-reqs"
+          - php: 7.0
+            composer-options: "--ignore-platform-reqs"
           - php: 8.0
             analysis: true
 
@@ -37,6 +41,8 @@ jobs:
 
       - name: Install dependencies with Composer
         uses: ramsey/composer-install@v1
+        with:
+          composer-options: "${{ matrix.composer-options }}"
 
       - name: Check code style with PHP_CodeSniffer
         if: matrix.analysis

--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,7 @@
     "phpunit/phpunit": "^4.8.36||^5||^6||^7",
     "phpmd/phpmd": "~2.9",
     "squizlabs/php_codesniffer": "~3.5",
-    "orchestra/testbench": "*",
-    "phpstan/phpstan": "^0.12.90"
+    "orchestra/testbench": "*"
   },
   "suggest": {
     "apigen/apigen": "Install with roave/better-reflection:dev-master to generate docs",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
     "phpunit/phpunit": "^4.8.36||^5||^6||^7",
     "phpmd/phpmd": "~2.9",
     "squizlabs/php_codesniffer": "~3.5",
-    "orchestra/testbench": "*"
+    "orchestra/testbench": "*",
+    "phpstan/phpstan": "^0.12.90"
   },
   "suggest": {
     "apigen/apigen": "Install with roave/better-reflection:dev-master to generate docs",

--- a/devtool/check_phpstan.sh
+++ b/devtool/check_phpstan.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Hacky solution as PHPStan requires PHP version >= 7.1
+
+composer require --dev phpstan/phpstan
+vendor/bin/phpstan analyse

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,5 @@
+parameters:
+  level: 1
+  paths:
+    - line-bot-sdk-tiny
+    - src


### PR DESCRIPTION
In this PR I tried to exclude PHPStan from the dev dependencies (as install it requires PHP version >= 7.1 and would break CI for PHP 5.6 and 7.0), and install it as part of CI in the latest PHP version that runs all the non-unit tests analysis.

It seems to be working,  `Run checks on PHP 7.4` is expected to fail as there are some violations for PHPStan rules.