### PR TITLE
Add publish config group for laravel project

### DIFF
--- a/src/Laravel/LINEBotServiceProvider.php
+++ b/src/Laravel/LINEBotServiceProvider.php
@@ -42,4 +42,16 @@ class LINEBotServiceProvider extends \Illuminate\Support\ServiceProvider
             return new LINEBot($httpClient, ['channelSecret' => config('line-bot.channel_secret')]);
         });
     }
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->publishes([
+            __DIR__ . '/config/line-bot.php' => config_path('line-bot.php'),
+        ], 'config');
+    }
 }

--- a/src/Laravel/LINEBotServiceProvider.php
+++ b/src/Laravel/LINEBotServiceProvider.php
@@ -50,8 +50,10 @@ class LINEBotServiceProvider extends \Illuminate\Support\ServiceProvider
      */
     public function boot()
     {
-        $this->publishes([
-            __DIR__ . '/config/line-bot.php' => config_path('line-bot.php'),
-        ], 'config');
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__ . '/config/line-bot.php' => config_path('line-bot.php'),
+            ], 'config');
+        }
     }
 }

--- a/tests/Laravel/Facade/LINEBotTest.php
+++ b/tests/Laravel/Facade/LINEBotTest.php
@@ -54,4 +54,14 @@ class LINEBotTest extends \Orchestra\Testbench\TestCase
         $this->assertEquals('test_channel_access_token', config('line-bot.channel_access_token'));
         $this->assertEquals('test_channel_secret', config('line-bot.channel_secret'));
     }
+
+    /**
+     * Testing LINEBot facade instance
+     * 
+     * @return void
+     */
+    public function testLINEBotFacadeInstance()
+    {
+        $this->assertInstanceOf(\LINE\LINEBot::class, LINEBot::getFacadeRoot());
+    }
 }

--- a/tests/Laravel/Facade/LINEBotTest.php
+++ b/tests/Laravel/Facade/LINEBotTest.php
@@ -57,7 +57,7 @@ class LINEBotTest extends \Orchestra\Testbench\TestCase
 
     /**
      * Testing LINEBot facade instance
-     * 
+     *
      * @return void
      */
     public function testLINEBotFacadeInstance()


### PR DESCRIPTION
-  Laravel project can publish the config file by running the following command:
```sh
$ php artisan vendor:publish --provider="LINE\Laravel\LINEBotServiceProvider" --tag="config"
# /config/line-bot.php
```

