### PR TITLE
Modify user agent

### DIFF
--- a/src/clients/channel-access-token/lib/Configuration.php
+++ b/src/clients/channel-access-token/lib/Configuration.php
@@ -115,7 +115,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = 'OpenAPI-Generator/1.0.0/PHP';
+    protected $userAgent = 'LINE-BotSDK-PHP/8';
 
     /**
      * Debug switch (default set to false)

--- a/src/clients/insight/lib/Configuration.php
+++ b/src/clients/insight/lib/Configuration.php
@@ -115,7 +115,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = 'OpenAPI-Generator/1.0.0/PHP';
+    protected $userAgent = 'LINE-BotSDK-PHP/8';
 
     /**
      * Debug switch (default set to false)

--- a/src/clients/liff/lib/Configuration.php
+++ b/src/clients/liff/lib/Configuration.php
@@ -115,7 +115,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = 'OpenAPI-Generator/1.0.0/PHP';
+    protected $userAgent = 'LINE-BotSDK-PHP/8';
 
     /**
      * Debug switch (default set to false)

--- a/src/clients/manage-audience/lib/Configuration.php
+++ b/src/clients/manage-audience/lib/Configuration.php
@@ -115,7 +115,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = 'OpenAPI-Generator/1.0.0/PHP';
+    protected $userAgent = 'LINE-BotSDK-PHP/8';
 
     /**
      * Debug switch (default set to false)

--- a/src/clients/messaging-api/lib/Configuration.php
+++ b/src/clients/messaging-api/lib/Configuration.php
@@ -115,7 +115,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = 'OpenAPI-Generator/1.0.0/PHP';
+    protected $userAgent = 'LINE-BotSDK-PHP/8';
 
     /**
      * Debug switch (default set to false)

--- a/tools/gen-oas-client.sh
+++ b/tools/gen-oas-client.sh
@@ -19,6 +19,7 @@ for schema in "${CLIENT_SCHEMAS[@]}"; do
     -i $REPO_ROOT_DIR/line-openapi/$schema.yml \
     -g php \
     -o $REPO_ROOT_DIR/src/clients/$schema \
+    --http-user-agent LINE-BotSDK-PHP/8 \
     --additional-properties="invokerPackage=LINE\Clients\\$camelSchemaName" \
     --additional-properties="variableNamingConvention=camelCase"
 done


### PR DESCRIPTION
Before version 8, user agent is `LINE-BotSDK-PHP/x.y.z`. LINE team wants to set user agent to know how many requests are created by line-bot-sdk-php. This pull request sets just version 8 as user agent. We can improve this more but I'm not sure how to achieve this.