### PR TITLE
Enable run diff-check workflow manually

### DIFF
--- a/.github/workflows/diff-check.yml
+++ b/.github/workflows/diff-check.yml
@@ -1,9 +1,10 @@
 name: Diff check
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      - 'master'
+      - master
 
 jobs:
   tests:
@@ -15,6 +16,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Update submodules
+        run: git submodule update --remote --recursive
       - uses: actions/setup-node@v3
         id: setup_node_id
         with:


### PR DESCRIPTION
Sometimes renovate can't work (I'm not sure if it's temporary or not). We'd like to run `diff-check` workflow manually in this situation...