### PR TITLE
Change renovate config to update all dependencies without review

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,19 +6,16 @@
   "ignorePaths": [
     "docs/",
   ],
+  "automerge": true,
+  "platformAutomerge": true,
   "git-submodules": {
     "enabled": true
   },
   "labels": [ "dependency upgrade" ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch", "digest"],
-      "automerge": true,
-      "platformAutomerge": true,
-    },
-    {
-      "matchPackagePatterns": ["^line-openapi$"],
-      "labels": ["dependency upgrade", "line-openapi-update"]
+        "matchPackagePatterns": ["^line-openapi$"],
+        "labels": ["dependency upgrade", "line-openapi-update"]
     }
   ]
 }


### PR DESCRIPTION
If CI past, merging will not be a big problem, so automatic merging is enabled considering maintenance costs.