### PR TITLE
Use published to run release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Deploy static content to Pages on release
 
 on:
   release:
-    types: [ created ]
+    types: [ published ]
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages


### PR DESCRIPTION
If we create release note as draft, and publish it, current workflow doesn't run. We should use `published`. 
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release