### PR TITLE
Add webhook definitions in EventRequestParser

### DIFF
--- a/src/parser/lib/EventRequestParser.php
+++ b/src/parser/lib/EventRequestParser.php
@@ -279,21 +279,10 @@ class EventRequestParser
     {
         $moduleContentType = $eventData['module']['type'];
 
-        // Debug: Output the module content type
-        error_log("Module content type: $moduleContentType");
-
         if (!isset(self::$moduleContentType2class[$moduleContentType])) {
             return new ModuleContent($eventData['module']);
         }
         $moduleContentClass = self::$moduleContentType2class[$moduleContentType];
-
-        // Debug: Output the class name
-        error_log("Instantiating class: $moduleContentClass");
-
-        $instance = new $moduleContentClass($eventData['module']);
-
-        // Debug: Output the instance class
-        error_log("Instance is of class: " . get_class($instance));
         return new $moduleContentClass($eventData['module']);
     }
 }

--- a/src/parser/lib/EventRequestParser.php
+++ b/src/parser/lib/EventRequestParser.php
@@ -223,6 +223,9 @@ class EventRequestParser
      */
     private static function parseSource($eventData): Source
     {
+        if (!isset($eventData['source'])) {
+            return new Source([]);
+        }
         $sourceType = $eventData['source']['type'];
         if (!isset(self::$sourceType2class[$sourceType])) {
             return new Source($eventData['source']);

--- a/src/parser/lib/EventRequestParser.php
+++ b/src/parser/lib/EventRequestParser.php
@@ -273,16 +273,28 @@ class EventRequestParser
     }
 
     /**
-     * Gets type
+     * @param array $eventData
      * @return ModuleContent
      */
     private static function parseModuleContent($eventData): ModuleContent
     {
         $moduleContentType = $eventData['module']['type'];
+
+        // Debug: Output the module content type
+        error_log("Module content type: $moduleContentType");
+
         if (!isset(self::$moduleContentType2class[$moduleContentType])) {
             return new ModuleContent($eventData['module']);
         }
         $moduleContentClass = self::$moduleContentType2class[$moduleContentType];
+
+        // Debug: Output the class name
+        error_log("Instantiating class: $moduleContentClass");
+
+        $instance = new $moduleContentClass($eventData['module']);
+
+        // Debug: Output the instance class
+        error_log("Instance is of class: " . get_class($instance));
         return new $moduleContentClass($eventData['module']);
     }
 }

--- a/src/parser/lib/EventRequestParser.php
+++ b/src/parser/lib/EventRequestParser.php
@@ -60,6 +60,12 @@ class EventRequestParser
         'memberJoined' => \LINE\Webhook\Model\MemberJoinedEvent::class,
         'memberLeft' => \LINE\Webhook\Model\MemberLeftEvent::class,
         'things' => \LINE\Webhook\Model\ThingsEvent::class,
+        'module' => \LINE\Webhook\Model\ModuleEvent::class,
+        'activated' => \LINE\Webhook\Model\ActivatedEvent::class,
+        'deactivated' => \LINE\Webhook\Model\DeactivatedEvent::class,
+        'botSuspended' => \LINE\Webhook\Model\BotSuspendedEvent::class,
+        'botResumed' => \LINE\Webhook\Model\BotResumedEvent::class,
+        'delivery' => \LINE\Webhook\Model\PnpDeliveryCompletionEvent::class,
     ];
 
     private static $messageType2class = [
@@ -92,6 +98,9 @@ class EventRequestParser
         'left' => \LINE\Webhook\Model\LeftMembers::class,
         'unsend' => \LINE\Webhook\Model\UnsendDetail::class,
         'videoPlayComplete' => \LINE\Webhook\Model\VideoPlayComplete::class,
+        'module' => \LINE\Webhook\Model\ModuleContent::class,
+        'chatControl' => \LINE\Webhook\Model\ChatControl::class,
+        'delivery' => \LINE\Webhook\Model\PnpDelivery::class,
     ];
 
     /**

--- a/src/parser/lib/EventRequestParser.php
+++ b/src/parser/lib/EventRequestParser.php
@@ -100,7 +100,6 @@ class EventRequestParser
         'left' => \LINE\Webhook\Model\LeftMembers::class,
         'unsend' => \LINE\Webhook\Model\UnsendDetail::class,
         'videoPlayComplete' => \LINE\Webhook\Model\VideoPlayComplete::class,
-        'module' => \LINE\Webhook\Model\ModuleContent::class,
         'chatControl' => \LINE\Webhook\Model\ChatControl::class,
         'delivery' => \LINE\Webhook\Model\PnpDelivery::class,
     ];

--- a/src/parser/test/EventRequestParserTest.php
+++ b/src/parser/test/EventRequestParserTest.php
@@ -1676,10 +1676,7 @@ class EventRequestParserTest extends TestCase
             /** @var \LINE\Webhook\Model\AttachedModuleContent $module */
             $module = $event->getModule();
 
-            $actualClassName = get_class($module);
-
             $this->assertInstanceOf(\LINE\Webhook\Model\AttachedModuleContent::class, $module);
-            $this->assertInstanceOf(\LINE\Webhook\Model\AttachedModuleContent::class, $module, "Expected 'LINE\Webhook\Model\AttachedModuleContent', got '$actualClassName'");
             $this->assertEquals('botid', $module->getBotId());
             $this->assertEquals('b', $module->getScopes()[1]);
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());

--- a/src/parser/test/EventRequestParserTest.php
+++ b/src/parser/test/EventRequestParserTest.php
@@ -925,7 +925,7 @@ class EventRequestParserTest extends TestCase
         $this->assertEquals($parsedEvents->getDestination(), 'U0123456789abcdef0123456789abcd');
 
         $events = $parsedEvents->getEvents();
-        $this->assertEquals(count($events), 39);
+        $this->assertEquals(count($events), 44);
 
         {
             // text
@@ -1636,7 +1636,7 @@ class EventRequestParserTest extends TestCase
             $this->assertInstanceOf(\LINE\Webhook\Model\PnpDelivery::class, $event->getDelivery());
             $this->assertEquals('deliverydata', $event->getDelivery()->getData());
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
-            $this->assertTrue($event->getDeliveryContext()->getIsRedelivery());
+            $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
         }
     }
 

--- a/src/parser/test/EventRequestParserTest.php
+++ b/src/parser/test/EventRequestParserTest.php
@@ -1679,7 +1679,7 @@ class EventRequestParserTest extends TestCase
             $actualClassName = get_class($module);
 
 //            $this->assertInstanceOf(\LINE\Webhook\Model\AttachedModuleContent::class, $module);
-            $this->assertInstanceOf(\LINE\Webhook\Model\AttachedModuleContent::class, $module, "Expected 'LINE\Webhook\Model\AttachedModuleContent', got '$actualClassName'");
+//            $this->assertInstanceOf(\LINE\Webhook\Model\AttachedModuleContent::class, $module, "Expected 'LINE\Webhook\Model\AttachedModuleContent', got '$actualClassName'");
             $this->assertEquals('botid', $module->getBotId());
             $this->assertEquals('b', $module->getScopes()[1]);
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
@@ -1692,9 +1692,12 @@ class EventRequestParserTest extends TestCase
             $this->assertEquals(12345678901234, $event->getTimestamp());
             $this->assertEquals('active', $event->getMode());
             $this->assertInstanceOf(\LINE\Webhook\Model\ModuleEvent::class, $event);
-            $this->assertInstanceOf(\LINE\Webhook\Model\DetachedModuleContent::class, $event->getModule());
-            $this->assertEquals('botid', $event->getModule()->getBotId());
-            $this->assertEquals('bot deleted', $event->getModule()->getReason());
+            /** @var \LINE\Webhook\Model\DetachedModuleContent $module */
+            $module = $event->getModule();
+
+//            $this->assertInstanceOf(\LINE\Webhook\Model\DetachedModuleContent::class, $event->getModule());
+            $this->assertEquals('botid', $module->getBotId());
+            $this->assertEquals('bot deleted', $module->getReason());
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
             $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
         }

--- a/src/parser/test/EventRequestParserTest.php
+++ b/src/parser/test/EventRequestParserTest.php
@@ -1678,8 +1678,8 @@ class EventRequestParserTest extends TestCase
 
             $actualClassName = get_class($module);
 
-//            $this->assertInstanceOf(\LINE\Webhook\Model\AttachedModuleContent::class, $module);
-//            $this->assertInstanceOf(\LINE\Webhook\Model\AttachedModuleContent::class, $module, "Expected 'LINE\Webhook\Model\AttachedModuleContent', got '$actualClassName'");
+            $this->assertInstanceOf(\LINE\Webhook\Model\AttachedModuleContent::class, $module);
+            $this->assertInstanceOf(\LINE\Webhook\Model\AttachedModuleContent::class, $module, "Expected 'LINE\Webhook\Model\AttachedModuleContent', got '$actualClassName'");
             $this->assertEquals('botid', $module->getBotId());
             $this->assertEquals('b', $module->getScopes()[1]);
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
@@ -1695,7 +1695,7 @@ class EventRequestParserTest extends TestCase
             /** @var \LINE\Webhook\Model\DetachedModuleContent $module */
             $module = $event->getModule();
 
-//            $this->assertInstanceOf(\LINE\Webhook\Model\DetachedModuleContent::class, $event->getModule());
+            $this->assertInstanceOf(\LINE\Webhook\Model\DetachedModuleContent::class, $event->getModule());
             $this->assertEquals('botid', $module->getBotId());
             $this->assertEquals('bot deleted', $module->getReason());
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());

--- a/src/parser/test/EventRequestParserTest.php
+++ b/src/parser/test/EventRequestParserTest.php
@@ -840,7 +840,70 @@ class EventRequestParserTest extends TestCase
           }
         ]
        }
-      }
+      },
+              {
+          "type": "activated",
+          "timestamp": 12345678901234,
+          "mode": "active",
+          "source": {
+            "type": "user",
+            "userId": "userid"
+          },
+          "chatControl": {
+            "expireAt": 1462629479860
+          },
+          "webhookEventId": "testwebhookeventid",
+          "deliveryContext": {
+            "isRedelivery": false
+          }
+        },
+                {
+          "type": "deactivated",
+          "timestamp": 12345678901234,
+          "mode": "active",
+          "source": {
+            "type": "user",
+            "userId": "userid"
+          },
+          "webhookEventId": "testwebhookeventid",
+          "deliveryContext": {
+            "isRedelivery": false
+          }
+        },
+                        {
+                  "type": "botSuspended",
+                  "timestamp": 12345678901234,
+                  "mode": "active",
+                  "webhookEventId": "testwebhookeventid",
+                  "deliveryContext": {
+                    "isRedelivery": false
+                  }
+                },
+        {
+                  "type": "botResumed",
+                  "timestamp": 12345678901234,
+                  "mode": "active",
+                  "webhookEventId": "testwebhookeventid",
+                  "deliveryContext": {
+                    "isRedelivery": false
+                  }
+                },
+                {
+                  "type": "delivery",
+                  "timestamp": 12345678901234,
+                  "mode": "active",
+                  "source": {
+                    "type": "user",
+                    "userId": "userid"
+                  },
+                  "delivery": {
+                    "data": "aaaaaaaaaa"
+                  },
+                  "webhookEventId": "testwebhookeventid",
+                  "deliveryContext": {
+                    "isRedelivery": false
+                  }
+                }
      ]
     }
     JSON;

--- a/src/parser/test/EventRequestParserTest.php
+++ b/src/parser/test/EventRequestParserTest.php
@@ -1673,9 +1673,11 @@ class EventRequestParserTest extends TestCase
             $this->assertEquals(12345678901234, $event->getTimestamp());
             $this->assertEquals('active', $event->getMode());
             $this->assertInstanceOf(\LINE\Webhook\Model\ModuleEvent::class, $event);
-            $this->assertInstanceOf(\LINE\Webhook\Model\AttachedModuleContent::class, $event->getModule());
-            $this->assertEquals('botid', $event->getModule()->getBotId());
-            $this->assertEquals('b', $event->getModule()->getScopes()[1]);
+            /** @var \LINE\Webhook\Model\AttachedModuleContent $things */
+            $module = $event->getModule();
+            $this->assertInstanceOf(\LINE\Webhook\Model\AttachedModuleContent::class, $module);
+            $this->assertEquals('botid', $module->getBotId());
+            $this->assertEquals('b', $module->getScopes()[1]);
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
             $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
         }

--- a/src/parser/test/EventRequestParserTest.php
+++ b/src/parser/test/EventRequestParserTest.php
@@ -841,69 +841,69 @@ class EventRequestParserTest extends TestCase
         ]
        }
       },
-              {
-          "type": "activated",
-          "timestamp": 12345678901234,
-          "mode": "active",
-          "source": {
-            "type": "user",
-            "userId": "userid"
-          },
-          "chatControl": {
-            "expireAt": 1462629479860
-          },
-          "webhookEventId": "testwebhookeventid",
-          "deliveryContext": {
-            "isRedelivery": false
-          }
+      {
+        "type": "activated",
+        "timestamp": 12345678901234,
+        "mode": "active",
+        "source": {
+          "type": "user",
+          "userId": "userid"
         },
-                {
-          "type": "deactivated",
-          "timestamp": 12345678901234,
-          "mode": "active",
-          "source": {
-            "type": "user",
-            "userId": "userid"
-          },
-          "webhookEventId": "testwebhookeventid",
-          "deliveryContext": {
-            "isRedelivery": false
-          }
+        "chatControl": {
+          "expireAt": 1462629479860
         },
-                        {
-                  "type": "botSuspended",
-                  "timestamp": 12345678901234,
-                  "mode": "active",
-                  "webhookEventId": "testwebhookeventid",
-                  "deliveryContext": {
-                    "isRedelivery": false
-                  }
-                },
-        {
-                  "type": "botResumed",
-                  "timestamp": 12345678901234,
-                  "mode": "active",
-                  "webhookEventId": "testwebhookeventid",
-                  "deliveryContext": {
-                    "isRedelivery": false
-                  }
-                },
-                {
-                  "type": "delivery",
-                  "timestamp": 12345678901234,
-                  "mode": "active",
-                  "source": {
-                    "type": "user",
-                    "userId": "userid"
-                  },
-                  "delivery": {
-                    "data": "aaaaaaaaaa"
-                  },
-                  "webhookEventId": "testwebhookeventid",
-                  "deliveryContext": {
-                    "isRedelivery": false
-                  }
-                }
+        "webhookEventId": "testwebhookeventid",
+        "deliveryContext": {
+          "isRedelivery": false
+        }
+      },
+      {
+        "type": "deactivated",
+        "timestamp": 12345678901234,
+        "mode": "active",
+        "source": {
+          "type": "user",
+          "userId": "userid"
+        },
+        "webhookEventId": "testwebhookeventid",
+        "deliveryContext": {
+          "isRedelivery": false
+        }
+      },
+      {
+        "type": "botSuspended",
+        "timestamp": 12345678901234,
+        "mode": "active",
+        "webhookEventId": "testwebhookeventid",
+        "deliveryContext": {
+          "isRedelivery": false
+        }
+      },
+      {
+        "type": "botResumed",
+        "timestamp": 12345678901234,
+        "mode": "active",
+        "webhookEventId": "testwebhookeventid",
+        "deliveryContext": {
+          "isRedelivery": false
+        }
+      },
+      {
+        "type": "delivery",
+        "timestamp": 12345678901234,
+        "mode": "active",
+        "source": {
+          "type": "user",
+          "userId": "userid"
+        },
+        "delivery": {
+          "data": "deliverydata"
+        },
+        "webhookEventId": "testwebhookeventid",
+        "deliveryContext": {
+          "isRedelivery": false
+        }
+      }
      ]
     }
     JSON;
@@ -1574,6 +1574,69 @@ class EventRequestParserTest extends TestCase
             $this->assertEquals(6, $emojiInfo->getLength());
             $this->assertEquals('5ac1bfd5040ab15980c9b435', $emojiInfo->getProductId());
             $this->assertEquals('001', $emojiInfo->getEmojiId());
+        }
+
+        {
+            // activated
+            $event = $events[39];
+            $source = $event->getSource();
+            $this->assertEquals(12345678901234, $event->getTimestamp());
+            $this->assertEquals('active', $event->getMode());
+            $this->assertTrue($source instanceof UserSource);
+            $this->assertEquals('userid', $source->getUserId());
+            $this->assertInstanceOf(\LINE\Webhook\Model\ActivatedEvent::class, $event);
+            $this->assertInstanceOf(\LINE\Webhook\Model\ChatControl::class, $event->getChatControl());
+            $this->assertEquals(1462629479860, $event->getChatControl()->getExpireAt());
+            $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
+            $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
+        }
+
+        {
+            // deactivated
+            $event = $events[40];
+            $source = $event->getSource();
+            $this->assertEquals(12345678901234, $event->getTimestamp());
+            $this->assertEquals('active', $event->getMode());
+            $this->assertTrue($source instanceof UserSource);
+            $this->assertEquals('userid', $source->getUserId());
+            $this->assertInstanceOf(\LINE\Webhook\Model\DeactivatedEvent::class, $event);
+            $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
+            $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
+        }
+
+        {
+            // botSuspended
+            $event = $events[41];
+            $this->assertEquals(12345678901234, $event->getTimestamp());
+            $this->assertEquals('active', $event->getMode());
+            $this->assertInstanceOf(\LINE\Webhook\Model\BotSuspendedEvent::class, $event);
+            $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
+            $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
+        }
+
+        {
+            // botResumed
+            $event = $events[42];
+            $this->assertEquals(12345678901234, $event->getTimestamp());
+            $this->assertEquals('active', $event->getMode());
+            $this->assertInstanceOf(\LINE\Webhook\Model\BotResumedEvent::class, $event);
+            $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
+            $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
+        }
+
+        {
+            // delivery
+            $event = $events[43];
+            $source = $event->getSource();
+            $this->assertEquals(12345678901234, $event->getTimestamp());
+            $this->assertEquals('active', $event->getMode());
+            $this->assertTrue($source instanceof UserSource);
+            $this->assertEquals('userid', $source->getUserId());
+            $this->assertInstanceOf(\LINE\Webhook\Model\PnpDeliveryCompletionEvent::class, $event);
+            $this->assertInstanceOf(\LINE\Webhook\Model\PnpDelivery::class, $event->getDelivery());
+            $this->assertEquals('deliverydata', $event->getDelivery()->getData());
+            $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
+            $this->assertTrue($event->getDeliveryContext()->getIsRedelivery());
         }
     }
 

--- a/src/parser/test/EventRequestParserTest.php
+++ b/src/parser/test/EventRequestParserTest.php
@@ -903,6 +903,34 @@ class EventRequestParserTest extends TestCase
         "deliveryContext": {
           "isRedelivery": false
         }
+      },
+      {
+        "type": "module",
+        "timestamp": 12345678901234,
+        "mode": "active",
+        "module": {
+          "type": "attached",
+          "botId": "botid",
+          "scopes": ["a", "b"]
+        },
+        "webhookEventId": "testwebhookeventid",
+        "deliveryContext": {
+          "isRedelivery": false
+        }
+      },
+      {
+        "type": "module",
+        "timestamp": 12345678901234,
+        "mode": "active",
+        "module": {
+          "type": "detached",
+          "botId": "botid",
+          "reason": "bot deleted"
+        },
+        "webhookEventId": "testwebhookeventid",
+        "deliveryContext": {
+          "isRedelivery": false
+        }
       }
      ]
     }
@@ -925,7 +953,7 @@ class EventRequestParserTest extends TestCase
         $this->assertEquals($parsedEvents->getDestination(), 'U0123456789abcdef0123456789abcd');
 
         $events = $parsedEvents->getEvents();
-        $this->assertEquals(count($events), 44);
+        $this->assertEquals(count($events), 46);
 
         {
             // text
@@ -1635,6 +1663,32 @@ class EventRequestParserTest extends TestCase
             $this->assertInstanceOf(\LINE\Webhook\Model\PnpDeliveryCompletionEvent::class, $event);
             $this->assertInstanceOf(\LINE\Webhook\Model\PnpDelivery::class, $event->getDelivery());
             $this->assertEquals('deliverydata', $event->getDelivery()->getData());
+            $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
+            $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
+        }
+
+        {
+            // module (attached)
+            $event = $events[44];
+            $this->assertEquals(12345678901234, $event->getTimestamp());
+            $this->assertEquals('active', $event->getMode());
+            $this->assertInstanceOf(\LINE\Webhook\Model\ModuleEvent::class, $event);
+            $this->assertInstanceOf(\LINE\Webhook\Model\AttachedModuleContent::class, $event->getModule());
+            $this->assertEquals('botid', $event->getModule()->getBotId());
+            $this->assertEquals('b', $event->getModule()->getScopes()[1]);
+            $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
+            $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
+        }
+
+        {
+            // module (detached)
+            $event = $events[45];
+            $this->assertEquals(12345678901234, $event->getTimestamp());
+            $this->assertEquals('active', $event->getMode());
+            $this->assertInstanceOf(\LINE\Webhook\Model\ModuleEvent::class, $event);
+            $this->assertInstanceOf(\LINE\Webhook\Model\DetachedModuleContent::class, $event->getModule());
+            $this->assertEquals('botid', $event->getModule()->getBotId());
+            $this->assertEquals('bot deleted', $event->getModule()->getReason());
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
             $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
         }

--- a/src/parser/test/EventRequestParserTest.php
+++ b/src/parser/test/EventRequestParserTest.php
@@ -1673,7 +1673,7 @@ class EventRequestParserTest extends TestCase
             $this->assertEquals(12345678901234, $event->getTimestamp());
             $this->assertEquals('active', $event->getMode());
             $this->assertInstanceOf(\LINE\Webhook\Model\ModuleEvent::class, $event);
-            /** @var \LINE\Webhook\Model\AttachedModuleContent $things */
+            /** @var \LINE\Webhook\Model\AttachedModuleContent $module */
             $module = $event->getModule();
 
             $actualClassName = get_class($module);

--- a/src/parser/test/EventRequestParserTest.php
+++ b/src/parser/test/EventRequestParserTest.php
@@ -1675,7 +1675,11 @@ class EventRequestParserTest extends TestCase
             $this->assertInstanceOf(\LINE\Webhook\Model\ModuleEvent::class, $event);
             /** @var \LINE\Webhook\Model\AttachedModuleContent $things */
             $module = $event->getModule();
-            $this->assertInstanceOf(\LINE\Webhook\Model\AttachedModuleContent::class, $module);
+
+            $actualClassName = get_class($module);
+
+//            $this->assertInstanceOf(\LINE\Webhook\Model\AttachedModuleContent::class, $module);
+            $this->assertInstanceOf(\LINE\Webhook\Model\AttachedModuleContent::class, $module, "Expected 'LINE\Webhook\Model\AttachedModuleContent', got '$actualClassName'");
             $this->assertEquals('botid', $module->getBotId());
             $this->assertEquals('b', $module->getScopes()[1]);
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());


### PR DESCRIPTION
This change allows SDK user to use 6 webhook events defined in https://github.com/line/line-openapi/blob/988429c5737e464bb891b949a874d5f389476681/webhook.yml#L111-L116 by modifying `EventRequestParser`.