### PR TITLE
Enhance Documentation for Response and Error Handling in SDK

### DIFF
--- a/examples/KitchenSink/composer.json
+++ b/examples/KitchenSink/composer.json
@@ -35,8 +35,9 @@
     "guzzlehttp/guzzle": "^7.5",
     "guzzlehttp/psr7": "^2.5",
     "php-di/slim-bridge": "^3.3",
-    "linecorp/line-bot-sdk": "dev-open-api"
+    "linecorp/line-bot-sdk": "*"
   },
+  "minimum-stability": "dev",
   "autoload": {
     "psr-4": {
       "LINE\\": "src/"


### PR DESCRIPTION
This pull request updates the README and example projects to include detailed instructions on how to retrieve headers and HTTP status codes from API responses. Additionally, it outlines methods for capturing HTTP status codes, headers, and error details when an error occurs. These enhancements aim to improve the developer's understanding and handling of API interactions and error management within the line-bot-sdk-php.