### PR TITLE
Add issueStatelessChannelToken test

### DIFF
--- a/test/clients/channel-access-token/Api/ChannelAccessTokenApiTest.php
+++ b/test/clients/channel-access-token/Api/ChannelAccessTokenApiTest.php
@@ -51,7 +51,7 @@ class ChannelAccessTokenApiTest extends TestCase
                 body: json_encode(['access_token' => 'accessToken', 'expires_in' => 30, 'token_type' => 'Bearer',]),
             ));
         $api = new ChannelAccessTokenApi($client);
-        $response = $api->issueStatelessChannelToken(grantType: "client_credentials", clientId: "1234", clientSecret: "channelSecret");
+        $response = $api->issueStatelessChannelToken(grantType: "client_credentials", clientId: "1234", clientSecret: "clientSecret");
         $this->assertEquals('accessToken', $response->getAccessToken());
         $this->assertEquals(30, $response->getExpiresIn());
         $this->assertEquals('Bearer', $response->getTokenType());


### PR DESCRIPTION
`/oauth2/v3/token` requires only 3 parameters, but client requires 5 parameters. Our client must work even if some of arguments are passed `null` like `client.issueStatelessChannelToken("client_credentials", null, null, "1234", "clientSecret")`. This change adds a test to verify this.