### PR TITLE
Limit the timing of git submodule updates by renovate to avoid disrupting work during working hours

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -17,7 +17,6 @@
     {
         "matchPackagePatterns": ["^line-openapi$"],
         "labels": ["dependency upgrade", "line-openapi-update"],
-        "labels": ["dependency upgrade", "line-openapi-update"],
         // In many cases, we would like to update line-openapi by dispatching the GitHub workflow during working
         // hours, as there are code changes.
         // If that is forgotten, there's a possibility that line-openapi updates or code changes won't happen at

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,6 +3,7 @@
   "extends": [
     "config:base"
   ],
+  "timezone": "Asia/Tokyo",
   "ignorePaths": [
     "docs/",
   ],
@@ -15,7 +16,13 @@
   "packageRules": [
     {
         "matchPackagePatterns": ["^line-openapi$"],
-        "labels": ["dependency upgrade", "line-openapi-update"]
+        "labels": ["dependency upgrade", "line-openapi-update"],
+        "labels": ["dependency upgrade", "line-openapi-update"],
+        // In many cases, we would like to update line-openapi by dispatching the GitHub workflow during working
+        // hours, as there are code changes.
+        // If that is forgotten, there's a possibility that line-openapi updates or code changes won't happen at
+        // all, so we allow it to run at night just in case.
+        "schedule": ["after 11pm and before 4am"]
     }
   ]
 }


### PR DESCRIPTION
same: https://github.com/line/line-bot-sdk-python/pull/743