### PR TITLE
Fix double-quote handling in release creation workflow

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -106,11 +106,14 @@ jobs:
             console.log(`releaseNotes (modified): ${JSON.stringify(modifiedBody, null, 2)}`);
             core.setOutput("release_body", modifiedBody);
 
+      - name: Write release notes to file
+        run: |
+          echo "${{ steps.generate-release-notes.outputs.release_body }}" > release-notes.txt
       - name: Create Draft Release
         run: |
           gh release create "${{ steps.calculate-version.outputs.new_version }}" \
             --title "${{ steps.calculate-version.outputs.new_version }} ${{ github.event.inputs.release_title }}" \
-            --notes "${{ steps.generate-release-notes.outputs.release_body }}" \
+            --notes-file release-notes.txt \
             --draft \
             --repo "${{ github.repository }}"
         env:

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -106,13 +106,24 @@ jobs:
             console.log(`releaseNotes (modified): ${JSON.stringify(modifiedBody, null, 2)}`);
             core.setOutput("release_body", modifiedBody);
 
-      - name: Write release notes to file
+      - name: Prepare Release Title
+        id: title
+        env:
+          # "vX.Y.Z Release Title"
+          RAW_TITLE: ${{ steps.calculate-version.outputs.new_version }} ${{ github.event.inputs.release_title }}
+        run: |
+          # Print RAW_TITLE safely, then escape double quotes
+          SANITIZED_TITLE="$(printf '%s' "$RAW_TITLE" | sed 's/"/\\"/g')"
+          echo "sanitized_title=$SANITIZED_TITLE" >> "$GITHUB_OUTPUT"
+
+      - name: Write Release Notes to File
         run: |
           echo "${{ steps.generate-release-notes.outputs.release_body }}" > release-notes.txt
+
       - name: Create Draft Release
         run: |
           gh release create "${{ steps.calculate-version.outputs.new_version }}" \
-            --title "${{ steps.calculate-version.outputs.new_version }} ${{ github.event.inputs.release_title }}" \
+            --title "${{ steps.title.outputs.sanitized_title }}" \
             --notes-file release-notes.txt \
             --draft \
             --repo "${{ github.repository }}"


### PR DESCRIPTION
This PR escapes the release title’s double quotes and provides the release notes via a file, preventing shell interpretation errors in the gh release create command.

Current workflow fails when 
(1) release title contains `"`: https://github.com/line/line-bot-sdk-java/actions/runs/12886931493/job/35928566569#step:6:3
or (2) PR title contains `"` (e.g. on reverting change, title is `revert "original title"`)

(same as https://github.com/line/line-bot-sdk-java/pull/1536)