### PR TITLE
Support PHP 8.4

### DIFF
--- a/.github/workflows/php-checks.yml
+++ b/.github/workflows/php-checks.yml
@@ -12,13 +12,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3]
+        php: [8.1, 8.2, 8.3, 8.4]
         include:
           - php: 8.1
             analysis: true
           - php: 8.2
             analysis: true
           - php: 8.3
+            analysis: true
+          - php: 8.4
             analysis: true
 
     steps:


### PR DESCRIPTION
Resolve https://github.com/line/line-bot-sdk-php/issues/641

To support PHP 8.4, I've added tests for PHP 8.4.
I will add `Run checks on PHP 8.4` jobs as required to Settings.

FYI:
The deprecated usages reported in https://github.com/line/line-bot-sdk-php/issues/625 can not be checked in this test if it is used in auto-generated files. Because auto-generated files have a lot of phpstan error included others than this, so we use phpstan only in non auto-generated files.