### PR TITLE
Stricter PHPStan level to 8

### DIFF
--- a/docs/classes/LINE-Laravel-LINEBotServiceProvider.html
+++ b/docs/classes/LINE-Laravel-LINEBotServiceProvider.html
@@ -148,7 +148,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/laravel/lib/LINEBotServiceProvider.php"><a href="files/src-laravel-lib-linebotserviceprovider.html"><abbr title="src/laravel/lib/LINEBotServiceProvider.php">LINEBotServiceProvider.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">24</span>
+    <span class="phpdocumentor-element-found-in__line">23</span>
 
     </aside>
 
@@ -222,7 +222,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/laravel/lib/LINEBotServiceProvider.php"><a href="files/src-laravel-lib-linebotserviceprovider.html"><abbr title="src/laravel/lib/LINEBotServiceProvider.php">LINEBotServiceProvider.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">60</span>
+    <span class="phpdocumentor-element-found-in__line">59</span>
 
     </aside>
 
@@ -266,7 +266,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/laravel/lib/LINEBotServiceProvider.php"><a href="files/src-laravel-lib-linebotserviceprovider.html"><abbr title="src/laravel/lib/LINEBotServiceProvider.php">LINEBotServiceProvider.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">29</span>
+    <span class="phpdocumentor-element-found-in__line">28</span>
 
     </aside>
 
@@ -304,7 +304,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/laravel/lib/LINEBotServiceProvider.php"><a href="files/src-laravel-lib-linebotserviceprovider.html"><abbr title="src/laravel/lib/LINEBotServiceProvider.php">LINEBotServiceProvider.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">67</span>
+    <span class="phpdocumentor-element-found-in__line">66</span>
 
     </aside>
 
@@ -337,7 +337,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/laravel/lib/LINEBotServiceProvider.php"><a href="files/src-laravel-lib-linebotserviceprovider.html"><abbr title="src/laravel/lib/LINEBotServiceProvider.php">LINEBotServiceProvider.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">86</span>
+    <span class="phpdocumentor-element-found-in__line">85</span>
 
     </aside>
 
@@ -370,7 +370,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/laravel/lib/LINEBotServiceProvider.php"><a href="files/src-laravel-lib-linebotserviceprovider.html"><abbr title="src/laravel/lib/LINEBotServiceProvider.php">LINEBotServiceProvider.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">102</span>
+    <span class="phpdocumentor-element-found-in__line">101</span>
 
     </aside>
 

--- a/docs/classes/LINE-Laravel-LINEBotServiceProvider.html
+++ b/docs/classes/LINE-Laravel-LINEBotServiceProvider.html
@@ -148,7 +148,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/laravel/lib/LINEBotServiceProvider.php"><a href="files/src-laravel-lib-linebotserviceprovider.html"><abbr title="src/laravel/lib/LINEBotServiceProvider.php">LINEBotServiceProvider.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">23</span>
+    <span class="phpdocumentor-element-found-in__line">24</span>
 
     </aside>
 
@@ -178,7 +178,7 @@
                     <dt class="phpdocumentor-table-of-contents__entry -property -private">
     <a href="classes/LINE-Laravel-LINEBotServiceProvider.html#property_apiBindings">$apiBindings</a>
     <span>
-                        &nbsp;: mixed            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd></dd>
 
@@ -199,7 +199,7 @@
             <dt class="phpdocumentor-table-of-contents__entry -method -private">
     <a href="classes/LINE-Laravel-LINEBotServiceProvider.html#method_bindApis">bindApis()</a>
     <span>
-                                &nbsp;: mixed    </span>
+                                &nbsp;: void    </span>
 </dt>
 <dd></dd>
 
@@ -222,7 +222,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/laravel/lib/LINEBotServiceProvider.php"><a href="files/src-laravel-lib-linebotserviceprovider.html"><abbr title="src/laravel/lib/LINEBotServiceProvider.php">LINEBotServiceProvider.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">56</span>
+    <span class="phpdocumentor-element-found-in__line">60</span>
 
     </aside>
 
@@ -266,20 +266,20 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/laravel/lib/LINEBotServiceProvider.php"><a href="files/src-laravel-lib-linebotserviceprovider.html"><abbr title="src/laravel/lib/LINEBotServiceProvider.php">LINEBotServiceProvider.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">25</span>
+    <span class="phpdocumentor-element-found-in__line">29</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$apiBindings</span>
      = <span class="phpdocumentor-signature__default-value">[&#039;line-bot-channel-access-token-api&#039; =&gt; [&#039;config&#039; =&gt; \LINE\Clients\ChannelAccessToken\Configuration::class, &#039;api&#039; =&gt; \LINE\Clients\ChannelAccessToken\Api\ChannelAccessTokenApi::class], &#039;line-bot-insight-api&#039; =&gt; [&#039;config&#039; =&gt; \LINE\Clients\Insight\Configuration::class, &#039;api&#039; =&gt; \LINE\Clients\Insight\Api\InsightApi::class], &#039;line-bot-liff-api&#039; =&gt; [&#039;config&#039; =&gt; \LINE\Clients\Liff\Configuration::class, &#039;api&#039; =&gt; \LINE\Clients\Liff\Api\LiffApi::class], &#039;line-bot-manage-audience-api&#039; =&gt; [&#039;config&#039; =&gt; \LINE\Clients\ManageAudience\Configuration::class, &#039;api&#039; =&gt; \LINE\Clients\ManageAudience\Api\ManageAudienceApi::class], &#039;line-bot-manage-audience-blob-api&#039; =&gt; [&#039;config&#039; =&gt; \LINE\Clients\ManageAudience\Configuration::class, &#039;api&#039; =&gt; \LINE\Clients\ManageAudience\Api\ManageAudienceBlobApi::class], &#039;line-bot-messaging-api&#039; =&gt; [&#039;config&#039; =&gt; \LINE\Clients\MessagingApi\Configuration::class, &#039;api&#039; =&gt; \LINE\Clients\MessagingApi\Api\MessagingApiApi::class], &#039;line-bot-messaging-blob-api&#039; =&gt; [&#039;config&#039; =&gt; \LINE\Clients\MessagingApi\Configuration::class, &#039;api&#039; =&gt; \LINE\Clients\MessagingApi\Api\MessagingApiBlobApi::class]]</span></code>
 
-        <section class="phpdocumentor-description"></section>
-
-        <section class="phpdocumentor-description"></section>
+    
+        <section class="phpdocumentor-description"><p>array&lt;string, array{config: class-string, api: class-string}&gt;</p>
+</section>
 
     
 
@@ -304,7 +304,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/laravel/lib/LINEBotServiceProvider.php"><a href="files/src-laravel-lib-linebotserviceprovider.html"><abbr title="src/laravel/lib/LINEBotServiceProvider.php">LINEBotServiceProvider.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">63</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 
@@ -337,7 +337,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/laravel/lib/LINEBotServiceProvider.php"><a href="files/src-laravel-lib-linebotserviceprovider.html"><abbr title="src/laravel/lib/LINEBotServiceProvider.php">LINEBotServiceProvider.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">82</span>
+    <span class="phpdocumentor-element-found-in__line">86</span>
 
     </aside>
 
@@ -370,14 +370,14 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/laravel/lib/LINEBotServiceProvider.php"><a href="files/src-laravel-lib-linebotserviceprovider.html"><abbr title="src/laravel/lib/LINEBotServiceProvider.php">LINEBotServiceProvider.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">98</span>
+    <span class="phpdocumentor-element-found-in__line">102</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-                    <span class="phpdocumentor-signature__name">bindApis</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">mixed&nbsp;</span><span class="phpdocumentor-signature__argument__name">$facadeName</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">mixed&nbsp;</span><span class="phpdocumentor-signature__argument__name">$clientClass</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">mixed&nbsp;</span><span class="phpdocumentor-signature__argument__name">$configClass</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
+                    <span class="phpdocumentor-signature__name">bindApis</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$facadeName</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$clientClass</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$configClass</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
 
         <section class="phpdocumentor-description"></section>
 
@@ -385,7 +385,7 @@
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$facadeName</span>
-                : <span class="phpdocumentor-signature__argument__return-type">mixed</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"></section>
@@ -393,7 +393,7 @@
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$clientClass</span>
-                : <span class="phpdocumentor-signature__argument__return-type">mixed</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"></section>
@@ -401,7 +401,7 @@
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$configClass</span>
-                : <span class="phpdocumentor-signature__argument__return-type">mixed</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"></section>
@@ -412,7 +412,7 @@
     
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">mixed</span>
+    <span class="phpdocumentor-signature__response_type">void</span>
             &mdash;
         
     

--- a/docs/classes/LINE-Laravel-Tests-Facades-FacadesTest.html
+++ b/docs/classes/LINE-Laravel-Tests-Facades-FacadesTest.html
@@ -201,14 +201,14 @@
             <dt class="phpdocumentor-table-of-contents__entry -method -protected">
     <a href="classes/LINE-Laravel-Tests-Facades-FacadesTest.html#method_getPackageAliases">getPackageAliases()</a>
     <span>
-                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+                                &nbsp;: array&lt;string, class-string&gt;    </span>
 </dt>
 <dd>Load package alias</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -protected">
     <a href="classes/LINE-Laravel-Tests-Facades-FacadesTest.html#method_getPackageProviders">getPackageProviders()</a>
     <span>
-                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+                                &nbsp;: array&lt;string|int, string&gt;    </span>
 </dt>
 <dd>Load package service provider</dd>
 
@@ -327,7 +327,7 @@
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">protected</span>
-                    <span class="phpdocumentor-signature__name">getPackageAliases</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\Illuminate\Foundation\Application">Application</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$app</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+                    <span class="phpdocumentor-signature__name">getPackageAliases</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\Illuminate\Foundation\Application">Application</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$app</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string, class-string&gt;</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -359,7 +359,7 @@
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string, class-string&gt;</span>
             &mdash;
         
     
@@ -385,7 +385,7 @@
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">protected</span>
-                    <span class="phpdocumentor-signature__name">getPackageProviders</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\Illuminate\Foundation\Application">Application</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$app</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+                    <span class="phpdocumentor-signature__name">getPackageProviders</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\Illuminate\Foundation\Application">Application</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$app</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, string&gt;</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -417,7 +417,7 @@
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, string&gt;</span>
             &mdash;
         
     

--- a/docs/classes/LINE-Parser-EventRequestParser.html
+++ b/docs/classes/LINE-Parser-EventRequestParser.html
@@ -145,7 +145,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/parser/lib/EventRequestParser.php"><a href="files/src-parser-lib-eventrequestparser.html"><abbr title="src/parser/lib/EventRequestParser.php">EventRequestParser.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">51</span>
+    <span class="phpdocumentor-element-found-in__line">52</span>
 
     </aside>
 
@@ -182,49 +182,49 @@
                     <dt class="phpdocumentor-table-of-contents__entry -property -private">
     <a href="classes/LINE-Parser-EventRequestParser.html#property_contentType2class">$contentType2class</a>
     <span>
-                        &nbsp;: mixed            </span>
+                        &nbsp;: array&lt;string, class-string&gt;            </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -private">
     <a href="classes/LINE-Parser-EventRequestParser.html#property_eventType2class">$eventType2class</a>
     <span>
-                        &nbsp;: mixed            </span>
+                        &nbsp;: array&lt;string, class-string<\LINE\Webhook\Model\Event>&gt;            </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -private">
     <a href="classes/LINE-Parser-EventRequestParser.html#property_membershipContentType2class">$membershipContentType2class</a>
     <span>
-                        &nbsp;: mixed            </span>
+                        &nbsp;: array&lt;string, class-string<\LINE\Webhook\Model\MembershipContent>&gt;            </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -private">
     <a href="classes/LINE-Parser-EventRequestParser.html#property_messageType2class">$messageType2class</a>
     <span>
-                        &nbsp;: mixed            </span>
+                        &nbsp;: array&lt;string, class-string<\LINE\Webhook\Model\MessageContent>&gt;            </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -private">
     <a href="classes/LINE-Parser-EventRequestParser.html#property_moduleContentType2class">$moduleContentType2class</a>
     <span>
-                        &nbsp;: mixed            </span>
+                        &nbsp;: array&lt;string, class-string<\LINE\Webhook\Model\ModuleContent>&gt;            </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -private">
     <a href="classes/LINE-Parser-EventRequestParser.html#property_sourceType2class">$sourceType2class</a>
     <span>
-                        &nbsp;: mixed            </span>
+                        &nbsp;: array&lt;string, class-string<\LINE\Webhook\Model\Source>&gt;            </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -private">
     <a href="classes/LINE-Parser-EventRequestParser.html#property_thingsContentType2class">$thingsContentType2class</a>
     <span>
-                        &nbsp;: mixed            </span>
+                        &nbsp;: array&lt;string, class-string<\LINE\Webhook\Model\ThingsContent>&gt;            </span>
 </dt>
 <dd></dd>
 
@@ -305,21 +305,19 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/parser/lib/EventRequestParser.php"><a href="files/src-parser-lib-eventrequestparser.html"><abbr title="src/parser/lib/EventRequestParser.php">EventRequestParser.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">98</span>
+    <span class="phpdocumentor-element-found-in__line">114</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string, class-string&gt;</span>
     <span class="phpdocumentor-signature__name">$contentType2class</span>
      = <span class="phpdocumentor-signature__default-value">[&#039;postback&#039; =&gt; \LINE\Webhook\Model\PostbackContent::class, &#039;beacon&#039; =&gt; \LINE\Webhook\Model\BeaconContent::class, &#039;link&#039; =&gt; \LINE\Webhook\Model\LinkContent::class, &#039;joined&#039; =&gt; \LINE\Webhook\Model\JoinedMembers::class, &#039;left&#039; =&gt; \LINE\Webhook\Model\LeftMembers::class, &#039;unsend&#039; =&gt; \LINE\Webhook\Model\UnsendDetail::class, &#039;videoPlayComplete&#039; =&gt; \LINE\Webhook\Model\VideoPlayComplete::class, &#039;chatControl&#039; =&gt; \LINE\Webhook\Model\ChatControl::class, &#039;delivery&#039; =&gt; \LINE\Webhook\Model\PnpDelivery::class]</span></code>
 
-        <section class="phpdocumentor-description"></section>
-
-        <section class="phpdocumentor-description"></section>
-
+    
+    
     
 
 </article>
@@ -339,21 +337,19 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/parser/lib/EventRequestParser.php"><a href="files/src-parser-lib-eventrequestparser.html"><abbr title="src/parser/lib/EventRequestParser.php">EventRequestParser.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">53</span>
+    <span class="phpdocumentor-element-found-in__line">57</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string, class-string<\LINE\Webhook\Model\Event>&gt;</span>
     <span class="phpdocumentor-signature__name">$eventType2class</span>
      = <span class="phpdocumentor-signature__default-value">[&#039;message&#039; =&gt; \LINE\Webhook\Model\MessageEvent::class, &#039;unsend&#039; =&gt; \LINE\Webhook\Model\UnsendEvent::class, &#039;follow&#039; =&gt; \LINE\Webhook\Model\FollowEvent::class, &#039;unfollow&#039; =&gt; \LINE\Webhook\Model\UnfollowEvent::class, &#039;join&#039; =&gt; \LINE\Webhook\Model\JoinEvent::class, &#039;leave&#039; =&gt; \LINE\Webhook\Model\LeaveEvent::class, &#039;postback&#039; =&gt; \LINE\Webhook\Model\PostbackEvent::class, &#039;videoPlayComplete&#039; =&gt; \LINE\Webhook\Model\VideoPlayCompleteEvent::class, &#039;beacon&#039; =&gt; \LINE\Webhook\Model\BeaconEvent::class, &#039;accountLink&#039; =&gt; \LINE\Webhook\Model\AccountLinkEvent::class, &#039;memberJoined&#039; =&gt; \LINE\Webhook\Model\MemberJoinedEvent::class, &#039;memberLeft&#039; =&gt; \LINE\Webhook\Model\MemberLeftEvent::class, &#039;things&#039; =&gt; \LINE\Webhook\Model\ThingsEvent::class, &#039;module&#039; =&gt; \LINE\Webhook\Model\ModuleEvent::class, &#039;activated&#039; =&gt; \LINE\Webhook\Model\ActivatedEvent::class, &#039;deactivated&#039; =&gt; \LINE\Webhook\Model\DeactivatedEvent::class, &#039;botSuspended&#039; =&gt; \LINE\Webhook\Model\BotSuspendedEvent::class, &#039;botResumed&#039; =&gt; \LINE\Webhook\Model\BotResumedEvent::class, &#039;delivery&#039; =&gt; \LINE\Webhook\Model\PnpDeliveryCompletionEvent::class, &#039;membership&#039; =&gt; \LINE\Webhook\Model\MembershipEvent::class]</span></code>
 
-        <section class="phpdocumentor-description"></section>
-
-        <section class="phpdocumentor-description"></section>
-
+    
+    
     
 
 </article>
@@ -373,21 +369,19 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/parser/lib/EventRequestParser.php"><a href="files/src-parser-lib-eventrequestparser.html"><abbr title="src/parser/lib/EventRequestParser.php">EventRequestParser.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">115</span>
+    <span class="phpdocumentor-element-found-in__line">137</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string, class-string<\LINE\Webhook\Model\MembershipContent>&gt;</span>
     <span class="phpdocumentor-signature__name">$membershipContentType2class</span>
      = <span class="phpdocumentor-signature__default-value">[&#039;joined&#039; =&gt; \LINE\Webhook\Model\JoinedMembershipContent::class, &#039;left&#039; =&gt; \LINE\Webhook\Model\LeftMembershipContent::class, &#039;renewed&#039; =&gt; \LINE\Webhook\Model\RenewedMembershipContent::class]</span></code>
 
-        <section class="phpdocumentor-description"></section>
-
-        <section class="phpdocumentor-description"></section>
-
+    
+    
     
 
 </article>
@@ -407,21 +401,19 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/parser/lib/EventRequestParser.php"><a href="files/src-parser-lib-eventrequestparser.html"><abbr title="src/parser/lib/EventRequestParser.php">EventRequestParser.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">76</span>
+    <span class="phpdocumentor-element-found-in__line">83</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string, class-string<\LINE\Webhook\Model\MessageContent>&gt;</span>
     <span class="phpdocumentor-signature__name">$messageType2class</span>
      = <span class="phpdocumentor-signature__default-value">[&#039;text&#039; =&gt; \LINE\Webhook\Model\TextMessageContent::class, &#039;image&#039; =&gt; \LINE\Webhook\Model\ImageMessageContent::class, &#039;video&#039; =&gt; \LINE\Webhook\Model\VideoMessageContent::class, &#039;audio&#039; =&gt; \LINE\Webhook\Model\AudioMessageContent::class, &#039;file&#039; =&gt; \LINE\Webhook\Model\FileMessageContent::class, &#039;location&#039; =&gt; \LINE\Webhook\Model\LocationMessageContent::class, &#039;sticker&#039; =&gt; \LINE\Webhook\Model\StickerMessageContent::class]</span></code>
 
-        <section class="phpdocumentor-description"></section>
-
-        <section class="phpdocumentor-description"></section>
-
+    
+    
     
 
 </article>
@@ -441,21 +433,19 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/parser/lib/EventRequestParser.php"><a href="files/src-parser-lib-eventrequestparser.html"><abbr title="src/parser/lib/EventRequestParser.php">EventRequestParser.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">110</span>
+    <span class="phpdocumentor-element-found-in__line">129</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string, class-string<\LINE\Webhook\Model\ModuleContent>&gt;</span>
     <span class="phpdocumentor-signature__name">$moduleContentType2class</span>
      = <span class="phpdocumentor-signature__default-value">[&#039;attached&#039; =&gt; \LINE\Webhook\Model\AttachedModuleContent::class, &#039;detached&#039; =&gt; \LINE\Webhook\Model\DetachedModuleContent::class]</span></code>
 
-        <section class="phpdocumentor-description"></section>
-
-        <section class="phpdocumentor-description"></section>
-
+    
+    
     
 
 </article>
@@ -475,21 +465,19 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/parser/lib/EventRequestParser.php"><a href="files/src-parser-lib-eventrequestparser.html"><abbr title="src/parser/lib/EventRequestParser.php">EventRequestParser.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">86</span>
+    <span class="phpdocumentor-element-found-in__line">96</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string, class-string<\LINE\Webhook\Model\Source>&gt;</span>
     <span class="phpdocumentor-signature__name">$sourceType2class</span>
      = <span class="phpdocumentor-signature__default-value">[&#039;user&#039; =&gt; \LINE\Webhook\Model\UserSource::class, &#039;group&#039; =&gt; \LINE\Webhook\Model\GroupSource::class, &#039;room&#039; =&gt; \LINE\Webhook\Model\RoomSource::class]</span></code>
 
-        <section class="phpdocumentor-description"></section>
-
-        <section class="phpdocumentor-description"></section>
-
+    
+    
     
 
 </article>
@@ -509,21 +497,19 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/parser/lib/EventRequestParser.php"><a href="files/src-parser-lib-eventrequestparser.html"><abbr title="src/parser/lib/EventRequestParser.php">EventRequestParser.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">92</span>
+    <span class="phpdocumentor-element-found-in__line">105</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string, class-string<\LINE\Webhook\Model\ThingsContent>&gt;</span>
     <span class="phpdocumentor-signature__name">$thingsContentType2class</span>
      = <span class="phpdocumentor-signature__default-value">[&#039;link&#039; =&gt; \LINE\Webhook\Model\LinkThingsContent::class, &#039;unlink&#039; =&gt; \LINE\Webhook\Model\UnlinkThingsContent::class, &#039;scenarioResult&#039; =&gt; \LINE\Webhook\Model\ScenarioResultThingsContent::class]</span></code>
 
-        <section class="phpdocumentor-description"></section>
-
-        <section class="phpdocumentor-description"></section>
-
+    
+    
     
 
 </article>
@@ -547,7 +533,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/parser/lib/EventRequestParser.php"><a href="files/src-parser-lib-eventrequestparser.html"><abbr title="src/parser/lib/EventRequestParser.php">EventRequestParser.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">129</span>
+    <span class="phpdocumentor-element-found-in__line">151</span>
 
     </aside>
 
@@ -625,26 +611,24 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/parser/lib/EventRequestParser.php"><a href="files/src-parser-lib-eventrequestparser.html"><abbr title="src/parser/lib/EventRequestParser.php">EventRequestParser.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">152</span>
+    <span class="phpdocumentor-element-found-in__line">178</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">parseEvent</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">mixed&nbsp;</span><span class="phpdocumentor-signature__argument__name">$eventData</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/LINE-Webhook-Model-Event.html"><abbr title="\LINE\Webhook\Model\Event">Event</abbr></a></span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">parseEvent</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">array&lt;string, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$eventData</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/LINE-Webhook-Model-Event.html"><abbr title="\LINE\Webhook\Model\Event">Event</abbr></a></span></code>
 
-        <section class="phpdocumentor-description"></section>
-
+    
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$eventData</span>
-                : <span class="phpdocumentor-signature__argument__return-type">mixed</span>
+                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string, mixed&gt;</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"></section>
-
+                
             </dd>
             </dl>
 
@@ -669,21 +653,21 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/parser/lib/EventRequestParser.php"><a href="files/src-parser-lib-eventrequestparser.html"><abbr title="src/parser/lib/EventRequestParser.php">EventRequestParser.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">307</span>
+    <span class="phpdocumentor-element-found-in__line">333</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">parseMembershipContent</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$eventData</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/LINE-Webhook-Model-MembershipContent.html"><abbr title="\LINE\Webhook\Model\MembershipContent">MembershipContent</abbr></a></span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">parseMembershipContent</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">array&lt;string, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$eventData</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/LINE-Webhook-Model-MembershipContent.html"><abbr title="\LINE\Webhook\Model\MembershipContent">MembershipContent</abbr></a></span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$eventData</span>
-                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;</span>
+                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string, mixed&gt;</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                 
@@ -711,21 +695,21 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/parser/lib/EventRequestParser.php"><a href="files/src-parser-lib-eventrequestparser.html"><abbr title="src/parser/lib/EventRequestParser.php">EventRequestParser.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">200</span>
+    <span class="phpdocumentor-element-found-in__line">226</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">parseMessageContent</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$eventData</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/LINE-Webhook-Model-MessageContent.html"><abbr title="\LINE\Webhook\Model\MessageContent">MessageContent</abbr></a></span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">parseMessageContent</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">array&lt;string, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$eventData</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/LINE-Webhook-Model-MessageContent.html"><abbr title="\LINE\Webhook\Model\MessageContent">MessageContent</abbr></a></span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$eventData</span>
-                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;</span>
+                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string, mixed&gt;</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                 
@@ -753,21 +737,21 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/parser/lib/EventRequestParser.php"><a href="files/src-parser-lib-eventrequestparser.html"><abbr title="src/parser/lib/EventRequestParser.php">EventRequestParser.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">292</span>
+    <span class="phpdocumentor-element-found-in__line">318</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">parseModuleContent</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$eventData</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/LINE-Webhook-Model-ModuleContent.html"><abbr title="\LINE\Webhook\Model\ModuleContent">ModuleContent</abbr></a></span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">parseModuleContent</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">array&lt;string, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$eventData</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/LINE-Webhook-Model-ModuleContent.html"><abbr title="\LINE\Webhook\Model\ModuleContent">ModuleContent</abbr></a></span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$eventData</span>
-                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;</span>
+                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string, mixed&gt;</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                 
@@ -795,21 +779,21 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/parser/lib/EventRequestParser.php"><a href="files/src-parser-lib-eventrequestparser.html"><abbr title="src/parser/lib/EventRequestParser.php">EventRequestParser.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">249</span>
+    <span class="phpdocumentor-element-found-in__line">275</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">parseSource</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$eventData</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/LINE-Webhook-Model-Source.html"><abbr title="\LINE\Webhook\Model\Source">Source</abbr></a></span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">parseSource</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">array&lt;string, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$eventData</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/LINE-Webhook-Model-Source.html"><abbr title="\LINE\Webhook\Model\Source">Source</abbr></a></span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$eventData</span>
-                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;</span>
+                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string, mixed&gt;</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                 
@@ -837,21 +821,21 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/parser/lib/EventRequestParser.php"><a href="files/src-parser-lib-eventrequestparser.html"><abbr title="src/parser/lib/EventRequestParser.php">EventRequestParser.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">267</span>
+    <span class="phpdocumentor-element-found-in__line">293</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">parseThingsContent</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$eventData</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/LINE-Webhook-Model-ThingsContent.html"><abbr title="\LINE\Webhook\Model\ThingsContent">ThingsContent</abbr></a></span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">parseThingsContent</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">array&lt;string, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$eventData</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/LINE-Webhook-Model-ThingsContent.html"><abbr title="\LINE\Webhook\Model\ThingsContent">ThingsContent</abbr></a></span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$eventData</span>
-                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;</span>
+                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string, mixed&gt;</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                 

--- a/docs/classes/LINE-Parser-Tests-EventRequestParserTest.html
+++ b/docs/classes/LINE-Parser-Tests-EventRequestParserTest.html
@@ -149,7 +149,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/parser/test/EventRequestParserTest.php"><a href="files/src-parser-test-eventrequestparsertest.html"><abbr title="src/parser/test/EventRequestParserTest.php">EventRequestParserTest.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">32</span>
 
     </aside>
 
@@ -172,14 +172,14 @@
                     <dt class="phpdocumentor-table-of-contents__entry -property -private">
     <a href="classes/LINE-Parser-Tests-EventRequestParserTest.html#property_json">$json</a>
     <span>
-                        &nbsp;: mixed            </span>
+                        &nbsp;: string            </span>
 </dt>
 <dd></dd>
 
                 <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/LINE-Parser-Tests-EventRequestParserTest.html#method_testParseEventRequest">testParseEventRequest()</a>
     <span>
-                                &nbsp;: mixed    </span>
+                                &nbsp;: void    </span>
 </dt>
 <dd></dd>
 
@@ -218,14 +218,14 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/parser/test/EventRequestParserTest.php"><a href="files/src-parser-test-eventrequestparsertest.html"><abbr title="src/parser/test/EventRequestParserTest.php">EventRequestParserTest.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">33</span>
+    <span class="phpdocumentor-element-found-in__line">34</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">$json</span>
      = <span class="phpdocumentor-signature__default-value">&lt;&lt;&lt;JSON
 {
@@ -1215,14 +1215,14 @@ JSON
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/parser/test/EventRequestParserTest.php"><a href="files/src-parser-test-eventrequestparsertest.html"><abbr title="src/parser/test/EventRequestParserTest.php">EventRequestParserTest.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">998</span>
+    <span class="phpdocumentor-element-found-in__line">1000</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                    <span class="phpdocumentor-signature__name">testParseEventRequest</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
+                    <span class="phpdocumentor-signature__name">testParseEventRequest</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
 
     
     
@@ -1256,10 +1256,18 @@ JSON
                                                             
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">throws</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                <span class="phpdocumentor-tag-link"><abbr title="\JsonException">JsonException</abbr></span>
+                                                            
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">mixed</span>
+    <span class="phpdocumentor-signature__response_type">void</span>
             &mdash;
         
     
@@ -1277,7 +1285,7 @@ JSON
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/parser/test/EventRequestParserTest.php"><a href="files/src-parser-test-eventrequestparsertest.html"><abbr title="src/parser/test/EventRequestParserTest.php">EventRequestParserTest.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1828</span>
+    <span class="phpdocumentor-element-found-in__line">1834</span>
 
     </aside>
 

--- a/docs/classes/LINE-Parser-Tests-SignatureValidatorTest.html
+++ b/docs/classes/LINE-Parser-Tests-SignatureValidatorTest.html
@@ -172,21 +172,21 @@
                     <dt class="phpdocumentor-table-of-contents__entry -property -private">
     <a href="classes/LINE-Parser-Tests-SignatureValidatorTest.html#property_channelSecret">$channelSecret</a>
     <span>
-                        &nbsp;: mixed            </span>
+                        &nbsp;: string            </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -private">
     <a href="classes/LINE-Parser-Tests-SignatureValidatorTest.html#property_json">$json</a>
     <span>
-                        &nbsp;: mixed            </span>
+                        &nbsp;: string            </span>
 </dt>
 <dd></dd>
 
                 <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/LINE-Parser-Tests-SignatureValidatorTest.html#method_testValidateSignature">testValidateSignature()</a>
     <span>
-                                &nbsp;: mixed    </span>
+                                &nbsp;: void    </span>
 </dt>
 <dd></dd>
 
@@ -225,7 +225,7 @@
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">$channelSecret</span>
      = <span class="phpdocumentor-signature__default-value">&#039;testsecret&#039;</span></code>
 
@@ -259,7 +259,7 @@
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">$json</span>
      = <span class="phpdocumentor-signature__default-value">&lt;&lt;&lt;JSON
 {
@@ -447,7 +447,7 @@ JSON
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                    <span class="phpdocumentor-signature__name">testValidateSignature</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
+                    <span class="phpdocumentor-signature__name">testValidateSignature</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
 
     
     
@@ -468,7 +468,7 @@ JSON
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">mixed</span>
+    <span class="phpdocumentor-signature__response_type">void</span>
             &mdash;
         
     

--- a/docs/reports/errors.html
+++ b/docs/reports/errors.html
@@ -130,9 +130,33 @@
 <div class="phpdocumentor-row">
     <h2 class="phpdocumentor-content__title">Errors</h2>
 
+        <h3>Table of Contents</h3>
+    <table class="phpdocumentor-table_of_contents">
+                                            <tr>
+                    <td class="phpdocumentor-cell"><a href="reports/errors.html#src/laravel/lib/LINEBotServiceProvider.php">src/laravel/lib/LINEBotServiceProvider.php</a></td>
+                    <td class="phpdocumentor-cell">1</td>
+                </tr>
+                                    </table>
     
-            <div class="phpdocumentor-admonition phpdocumentor-admonition--success">No errors have been found in this project.</div>
     
+            <a id="src/laravel/lib/LINEBotServiceProvider.php"></a>
+        <h3><abbr title="src/laravel/lib/LINEBotServiceProvider.php">LINEBotServiceProvider.php</abbr></h3>
+        <table>
+            <thead>
+                <tr>
+                    <th class="phpdocumentor-heading">Type</th>
+                    <th class="phpdocumentor-heading">Line</th>
+                    <th class="phpdocumentor-heading">Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                            <tr>
+                    <td class="phpdocumentor-cell">ERROR</td>
+                    <td class="phpdocumentor-cell">0</td>
+                    <td class="phpdocumentor-cell">Tag &quot;var&quot; with body &quot;@var array&lt;string, array{config: class-string, api: class-string}&gt;&quot; has error &quot;\LINE\Laravel\array{config: class-string&quot; is not a valid Fqsen.</td>
+                </tr>
+                        </tbody>
+        </table>
     </div>
                 <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
     <section class="phpdocumentor-search-results__dialog">

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-  level: 5
+  level: 8
   paths:
     - src/constants
     - src/laravel

--- a/src/laravel/lib/LINEBotServiceProvider.php
+++ b/src/laravel/lib/LINEBotServiceProvider.php
@@ -19,10 +19,14 @@
 namespace LINE\Laravel;
 
 use GuzzleHttp\Client as GuzzleHttpClient;
+use LINE\Clients\Liff\Configuration;
 
 class LINEBotServiceProvider extends \Illuminate\Support\ServiceProvider
 {
-    private static $apiBindings = [
+    /**
+     * @var array<string, array{config: class-string, api: class-string}>
+     */
+    private static array $apiBindings = [
         'line-bot-channel-access-token-api' => [
             'config' => \LINE\Clients\ChannelAccessToken\Configuration::class,
             'api' => \LINE\Clients\ChannelAccessToken\Api\ChannelAccessTokenApi::class,
@@ -60,7 +64,7 @@ class LINEBotServiceProvider extends \Illuminate\Support\ServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         if ($this->app->runningInConsole()) {
             $this->publishes(
@@ -79,7 +83,7 @@ class LINEBotServiceProvider extends \Illuminate\Support\ServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->mergeConfigFrom(
             self::CONFIG_PATH,
@@ -95,11 +99,11 @@ class LINEBotServiceProvider extends \Illuminate\Support\ServiceProvider
         }
     }
 
-    private function bindApis($facadeName, $clientClass, $configClass)
+    private function bindApis(string $facadeName, string $clientClass, string $configClass): void
     {
         $this->app->bind($facadeName, function ($app) use ($clientClass, $configClass) {
             $httpClient = $app->make('line-bot-http-client');
-            $config = new $configClass();
+            $config = new $configClass();   // @phpstan-ignore-next-line
             $config->setAccessToken(config('line-bot.channel_access_token'));
             return new $clientClass(
                 client: $httpClient,

--- a/src/laravel/lib/LINEBotServiceProvider.php
+++ b/src/laravel/lib/LINEBotServiceProvider.php
@@ -19,7 +19,6 @@
 namespace LINE\Laravel;
 
 use GuzzleHttp\Client as GuzzleHttpClient;
-use LINE\Clients\Liff\Configuration;
 
 class LINEBotServiceProvider extends \Illuminate\Support\ServiceProvider
 {

--- a/src/laravel/test/Facades/FacadesTest.php
+++ b/src/laravel/test/Facades/FacadesTest.php
@@ -28,9 +28,9 @@ class FacadesTest extends \Orchestra\Testbench\TestCase
      *
      * @SuppressWarnings("PHPMD.UnusedFormalParameter")
      * @param  \Illuminate\Foundation\Application $app
-     * @return array
+     * @return array<string>
      */
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return ['LINE\Laravel\LINEBotServiceProvider'];
     }
@@ -40,9 +40,9 @@ class FacadesTest extends \Orchestra\Testbench\TestCase
      *
      * @SuppressWarnings("PHPMD.UnusedFormalParameter")
      * @param  \Illuminate\Foundation\Application $app
-     * @return array
+     * @return array<string, class-string>
      */
-    protected function getPackageAliases($app)
+    protected function getPackageAliases($app): array
     {
         return [
             'LINEChannelAccessTokenApi' => \LINE\Laravel\Facades\LINEChannelAccessTokenApi::class,
@@ -60,7 +60,7 @@ class FacadesTest extends \Orchestra\Testbench\TestCase
      *
      * @return void
      */
-    public function testConfigLoaded()
+    public function testConfigLoaded(): void
     {
         $this->assertEquals('test_channel_access_token', config('line-bot.channel_access_token'));
         $this->assertEquals('test_channel_secret', config('line-bot.channel_secret'));
@@ -72,7 +72,7 @@ class FacadesTest extends \Orchestra\Testbench\TestCase
      * @SuppressWarnings("PHPMD.UnusedFormalParameter")
      * @return void
      */
-    public function testLINEBotFacadeInstance()
+    public function testLINEBotFacadeInstance(): void
     {
         $this->assertInstanceOf(\LINE\Clients\ChannelAccessToken\Api\ChannelAccessTokenApi::class, \LINEChannelAccessTokenApi::getFacadeRoot());
         $this->assertInstanceOf(\LINE\Clients\Insight\Api\InsightApi::class, \LINEInsightApi::getFacadeRoot());

--- a/src/parser/lib/EventRequestParser.php
+++ b/src/parser/lib/EventRequestParser.php
@@ -35,6 +35,7 @@ use LINE\Webhook\Model\ImageSet;
 use LINE\Webhook\Model\Mention;
 use LINE\Webhook\Model\Mentionee;
 use LINE\Webhook\Model\MessageContent;
+use LINE\Webhook\Model\ModelInterface;
 use LINE\Webhook\Model\ModuleContent;
 use LINE\Webhook\Model\ModuleEvent;
 use LINE\Webhook\Model\ScenarioResult;
@@ -50,6 +51,9 @@ use LINE\Webhook\Model\UserMentionee;
  */
 class EventRequestParser
 {
+    /**
+     * @var array<string, class-string<Event>>
+     */
     private static $eventType2class = [
         'message' => \LINE\Webhook\Model\MessageEvent::class,
         'unsend' => \LINE\Webhook\Model\UnsendEvent::class,
@@ -73,6 +77,9 @@ class EventRequestParser
         'membership' => \LINE\Webhook\Model\MembershipEvent::class,
     ];
 
+    /**
+     * @var array<string, class-string<MessageContent>>
+     */
     private static $messageType2class = [
         'text' => \LINE\Webhook\Model\TextMessageContent::class,
         'image' => \LINE\Webhook\Model\ImageMessageContent::class,
@@ -83,18 +90,27 @@ class EventRequestParser
         'sticker' => \LINE\Webhook\Model\StickerMessageContent::class,
     ];
 
+    /**
+     * @var array<string, class-string<Source>>
+     */
     private static $sourceType2class = [
         'user' => \LINE\Webhook\Model\UserSource::class,
         'group' => \LINE\Webhook\Model\GroupSource::class,
         'room' => \LINE\Webhook\Model\RoomSource::class,
     ];
 
+    /**
+     * @var array<string, class-string<ThingsContent>>
+     */
     private static $thingsContentType2class = [
         'link' => \LINE\Webhook\Model\LinkThingsContent::class,
         'unlink' => \LINE\Webhook\Model\UnlinkThingsContent::class,
         'scenarioResult' => \LINE\Webhook\Model\ScenarioResultThingsContent::class,
     ];
 
+    /**
+     * @var array<string, class-string>
+     */
     private static $contentType2class = [
         'postback' => \LINE\Webhook\Model\PostbackContent::class,
         'beacon' => \LINE\Webhook\Model\BeaconContent::class,
@@ -107,11 +123,17 @@ class EventRequestParser
         'delivery' => \LINE\Webhook\Model\PnpDelivery::class,
     ];
 
+    /**
+     * @var array<string, class-string<ModuleContent>>
+     */
     private static $moduleContentType2class = [
         'attached' => \LINE\Webhook\Model\AttachedModuleContent::class,
         'detached' => \LINE\Webhook\Model\DetachedModuleContent::class,
     ];
 
+    /**
+     * @var array<string, class-string<MembershipContent>>
+     */
     private static $membershipContentType2class = [
         'joined' => \LINE\Webhook\Model\JoinedMembershipContent::class,
         'left' => \LINE\Webhook\Model\LeftMembershipContent::class,
@@ -149,6 +171,10 @@ class EventRequestParser
         return new ParsedEvents($parsedReq['destination'] ?? null, $events);
     }
 
+    /**
+     * @param array<string, mixed> $eventData
+     * @return Event
+     */
     private static function parseEvent($eventData): Event
     {
         $eventType = $eventData['type'];
@@ -194,7 +220,7 @@ class EventRequestParser
     }
 
     /**
-     * @param array $eventData
+     * @param array<string, mixed> $eventData
      * @return MessageContent
      */
     private static function parseMessageContent($eventData): MessageContent
@@ -243,7 +269,7 @@ class EventRequestParser
     }
 
     /**
-     * @param array $eventData
+     * @param array<string, mixed> $eventData
      * @return Source
      */
     private static function parseSource($eventData): Source
@@ -261,7 +287,7 @@ class EventRequestParser
     }
 
     /**
-     * @param array $eventData
+     * @param array<string, mixed> $eventData
      * @return ThingsContent
      */
     private static function parseThingsContent($eventData): ThingsContent
@@ -286,7 +312,7 @@ class EventRequestParser
     }
 
     /**
-     * @param array $eventData
+     * @param array<string, mixed> $eventData
      * @return ModuleContent
      */
     private static function parseModuleContent($eventData): ModuleContent
@@ -301,7 +327,7 @@ class EventRequestParser
     }
 
     /**
-     * @param array $eventData
+     * @param array<string, mixed> $eventData
      * @return MembershipContent
      */
     private static function parseMembershipContent($eventData): MembershipContent

--- a/src/parser/test/EventRequestParserTest.php
+++ b/src/parser/test/EventRequestParserTest.php
@@ -28,7 +28,6 @@ use LINE\Webhook\Model\GroupSource;
 use LINE\Webhook\Model\RoomSource;
 use LINE\Webhook\Model\UserSource;
 use PHPUnit\Framework\TestCase;
-use function PHPUnit\Framework\assertInstanceOf;
 
 class EventRequestParserTest extends TestCase
 {

--- a/src/parser/test/EventRequestParserTest.php
+++ b/src/parser/test/EventRequestParserTest.php
@@ -23,14 +23,16 @@ use LINE\Constants\StickerResourceType;
 use LINE\Constants\ThingsEventType;
 use LINE\Constants\ThingsResultContentType;
 use LINE\Parser\EventRequestParser;
+use LINE\Webhook\Model\Event;
 use LINE\Webhook\Model\GroupSource;
 use LINE\Webhook\Model\RoomSource;
 use LINE\Webhook\Model\UserSource;
 use PHPUnit\Framework\TestCase;
+use function PHPUnit\Framework\assertInstanceOf;
 
 class EventRequestParserTest extends TestCase
 {
-    private static $json = <<<JSON
+    private static string $json = <<<JSON
     {
      "destination":"U0123456789abcdef0123456789abcd",
      "events":[
@@ -994,15 +996,16 @@ class EventRequestParserTest extends TestCase
      * @throws \LINE\Parser\Exception\InvalidEventRequestException
      * @throws \LINE\Parser\Exception\InvalidEventSourceException
      * @throws \LINE\Parser\Exception\InvalidSignatureException
+     * @throws \JsonException
      */
-    public function testParseEventRequest()
+    public function testParseEventRequest(): void
     {
         $parsedEvents = EventRequestParser::parseEventRequest(
             body: self::$json,
             channelSecret: 'testsecret',
             signature: self::getSignature('testsecret'),
         );
-        $eventArrays = json_decode(self::$json, true)["events"];
+        $eventArrays = json_decode(self::$json, true, 512, JSON_THROW_ON_ERROR)["events"];
 
         $this->assertEquals($parsedEvents->getDestination(), 'U0123456789abcdef0123456789abcd');
 
@@ -1015,18 +1018,19 @@ class EventRequestParserTest extends TestCase
             $source = $event->getSource();
             $this->assertEquals(12345678901234, $event->getTimestamp());
             $this->assertEquals('active', $event->getMode());
-            $this->assertTrue($source instanceof UserSource);
+            $this->assertInstanceOf(UserSource::class, $source);
             $this->assertEquals('userid', $source->getUserId());
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
             $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
-            $this->assertJsonStringEqualsJsonString(json_encode($eventArrays[0]), $event->__toString());
+            $this->assertJsonStringEqualsJsonString(json_encode($eventArrays[0], JSON_THROW_ON_ERROR), $event->__toString());
             $this->assertInstanceOf(\LINE\Webhook\Model\MessageEvent::class, $event);
             $this->assertInstanceOf(\LINE\Webhook\Model\TextMessageContent::class, $event->getMessage());
             $this->assertEquals('replytoken', $event->getReplyToken());
             $this->assertEquals('contentid', $event->getMessage()->getId());
             $this->assertEquals('text', $event->getMessage()->getType());
             $this->assertEquals('message (love)', $event->getMessage()->getText());
-            $emojiInfo = $event->getMessage()->getEmojis()[0];
+            $emojiInfo = $event->getMessage()->getEmojis()[0] ?? null;
+            $this->assertInstanceOf(\LINE\Webhook\Model\Emoji::class, $emojiInfo);
             $this->assertEquals(8, $emojiInfo->getIndex());
             $this->assertEquals(6, $emojiInfo->getLength());
             $this->assertEquals('5ac1bfd5040ab15980c9b435', $emojiInfo->getProductId());
@@ -1037,12 +1041,12 @@ class EventRequestParserTest extends TestCase
             // image
             $event = $events[1];
             $source = $event->getSource();
-            $this->assertTrue($source instanceof GroupSource);
+            $this->assertInstanceOf(GroupSource::class, $source);
             $this->assertEquals('groupid', $source->getGroupId());
             $this->assertEquals(null, $source->getUserId());
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
             $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
-            $this->assertJsonStringEqualsJsonString(json_encode($eventArrays[1]), $event->__toString());
+            $this->assertJsonStringEqualsJsonString(json_encode($eventArrays[1], JSON_THROW_ON_ERROR), $event->__toString());
             $this->assertInstanceOf(\LINE\Webhook\Model\MessageEvent::class, $event);
             $this->assertInstanceOf(\LINE\Webhook\Model\ImageMessageContent::class, $event->getMessage());
             $this->assertEquals('replytoken', $event->getReplyToken());
@@ -1059,21 +1063,21 @@ class EventRequestParserTest extends TestCase
             );
             $this->assertEquals(
                 'E005D41A7288F41B65593ED38FF6E9834B046AB36A37921A56BC236F13A91855',
-                $event->getMessage()->getImageSet()->getId()
+                $event->getMessage()->getImageSet()?->getId()
             );
-            $this->assertEquals(1, $event->getMessage()->getImageSet()->getIndex());
-            $this->assertEquals(1, $event->getMessage()->getImageSet()->getTotal());
+            $this->assertEquals(1, $event->getMessage()->getImageSet()?->getIndex());
+            $this->assertEquals(1, $event->getMessage()->getImageSet()?->getTotal());
         }
 
         {
             // audio (group event & it has user ID)
             $event = $events[2];
             $source = $event->getSource();
-            $this->assertTrue($source instanceof GroupSource);
+            $this->assertInstanceOf(GroupSource::class, $source);
             $this->assertEquals('groupid', $source->getGroupId());
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
             $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
-            $this->assertJsonStringEqualsJsonString(json_encode($eventArrays[2]), $event->__toString());
+            $this->assertJsonStringEqualsJsonString(json_encode($eventArrays[2], JSON_THROW_ON_ERROR), $event->__toString());
             $this->assertInstanceOf(\LINE\Webhook\Model\MessageEvent::class, $event);
             $this->assertInstanceOf(\LINE\Webhook\Model\AudioMessageContent::class, $event->getMessage());
             $this->assertEquals('userid', $source->getUserId());
@@ -1092,12 +1096,12 @@ class EventRequestParserTest extends TestCase
             // video
             $event = $events[3];
             $source = $event->getSource();
-            $this->assertTrue($source instanceof RoomSource);
+            $this->assertInstanceOf(RoomSource::class, $source);
             $this->assertEquals('roomid', $source->getRoomId());
             $this->assertEquals(null, $source->getUserId());
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
             $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
-            $this->assertJsonStringEqualsJsonString(json_encode($eventArrays[3]), $event->__toString());
+            $this->assertJsonStringEqualsJsonString(json_encode($eventArrays[3], JSON_THROW_ON_ERROR), $event->__toString());
             $this->assertInstanceOf(\LINE\Webhook\Model\MessageEvent::class, $event);
             $this->assertInstanceOf(\LINE\Webhook\Model\VideoMessageContent::class, $event->getMessage());
             $this->assertEquals('replytoken', $event->getReplyToken());
@@ -1118,7 +1122,7 @@ class EventRequestParserTest extends TestCase
             // audio
             $event = $events[4];
             $source = $event->getSource();
-            $this->assertTrue($source instanceof RoomSource);
+            $this->assertInstanceOf(RoomSource::class, $source);
             $this->assertEquals('userid', $source->getUserId());
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
             $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
@@ -1477,6 +1481,7 @@ class EventRequestParserTest extends TestCase
             $this->assertEquals('success', $scenarioResult->getResultCode());
             $this->assertEquals('AQ==', $scenarioResult->getBleNotificationPayload());
             $actionResults = $scenarioResult->getActionResults();
+            $this->assertNotEmpty($actionResults);
             $this->assertEquals(ThingsResultContentType::TYPE_BINARY, $actionResults[0]->getType());
             $this->assertEquals('/w==', $actionResults[0]->getData());
         }
@@ -1484,10 +1489,11 @@ class EventRequestParserTest extends TestCase
         {
             // text without emoji
             $event = $events[30];
+            $this->assertInstanceOf(Event::class, $event);
             $source = $event->getSource();
             $this->assertEquals(12345678901234, $event->getTimestamp());
             $this->assertEquals('active', $event->getMode());
-            $this->assertTrue($source instanceof UserSource);
+            $this->assertInstanceOf(UserSource::class, $source);
             $this->assertEquals('userid', $source->getUserId());
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
             $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
@@ -1528,7 +1534,7 @@ class EventRequestParserTest extends TestCase
             $source = $event->getSource();
             $this->assertEquals(1462629479859, $event->getTimestamp());
             $this->assertEquals('active', $event->getMode());
-            $this->assertTrue($source instanceof UserSource);
+            $this->assertInstanceOf(UserSource::class, $source);
             $this->assertEquals('U4af4980629...', $source->getUserId());
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
             $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
@@ -1538,7 +1544,7 @@ class EventRequestParserTest extends TestCase
             $this->assertEquals('325708', $event->getMessage()->getId());
             $this->assertEquals('text', $event->getMessage()->getType());
             $this->assertEquals('@example Hello, world! (love)', $event->getMessage()->getText());
-            $mentioneeInfo = $event->getMessage()->getMention()->getMentionees()[0];
+            $mentioneeInfo = $event->getMessage()->getMention()?->getMentionees()[0];
             $this->assertInstanceOf(\LINE\Webhook\Model\UserMentionee::class, $mentioneeInfo);
             $this->assertEquals(0, $mentioneeInfo->getIndex());
             $this->assertEquals(8, $mentioneeInfo->getLength());
@@ -1551,7 +1557,7 @@ class EventRequestParserTest extends TestCase
             $source = $event->getSource();
             $this->assertEquals(1462629479859, $event->getTimestamp());
             $this->assertEquals('active', $event->getMode());
-            $this->assertTrue($source instanceof UserSource);
+            $this->assertInstanceOf(UserSource::class, $source);
             $this->assertEquals('U0123456789abcd0123456789abcdef', $source->getUserId());
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
             $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
@@ -1561,7 +1567,7 @@ class EventRequestParserTest extends TestCase
             $this->assertEquals('325708', $event->getMessage()->getId());
             $this->assertEquals('text', $event->getMessage()->getType());
             $this->assertEquals('@example message without mentionee userId', $event->getMessage()->getText());
-            $mentioneeInfo = $event->getMessage()->getMention()->getMentionees()[0];
+            $mentioneeInfo = $event->getMessage()->getMention()?->getMentionees()[0];
             $this->assertInstanceOf(\LINE\Webhook\Model\AllMentionee::class, $mentioneeInfo);
             $this->assertEquals(0, $mentioneeInfo->getIndex());
             $this->assertEquals(8, $mentioneeInfo->getLength());
@@ -1573,7 +1579,7 @@ class EventRequestParserTest extends TestCase
             $source = $event->getSource();
             $this->assertEquals(1462629479859, $event->getTimestamp());
             $this->assertEquals('active', $event->getMode());
-            $this->assertTrue($source instanceof UserSource);
+            $this->assertInstanceOf(UserSource::class, $source);
             $this->assertEquals('U0123456789abcd0123456789abcdef', $source->getUserId());
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
             $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
@@ -1590,12 +1596,12 @@ class EventRequestParserTest extends TestCase
             // Only included when multiple images are sent simultaneously.
             $event = $events[36];
             $source = $event->getSource();
-            $this->assertTrue($source instanceof GroupSource);
+            $this->assertInstanceOf(GroupSource::class, $source);
             $this->assertEquals('groupid', $source->getGroupId());
             $this->assertEquals(null, $source->getUserId());
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
             $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
-            $this->assertJsonStringEqualsJsonString(json_encode($eventArrays[36]), $event->__toString());
+            $this->assertJsonStringEqualsJsonString(json_encode($eventArrays[36], JSON_THROW_ON_ERROR), $event->__toString());
             $this->assertInstanceOf(\LINE\Webhook\Model\MessageEvent::class, $event);
             $this->assertInstanceOf(\LINE\Webhook\Model\ImageMessageContent::class, $event->getMessage());
             $this->assertEquals('replytoken', $event->getReplyToken());
@@ -1617,12 +1623,12 @@ class EventRequestParserTest extends TestCase
             // However, it won't be included if the sender is using LINE 11.15 or earlier for Android.
             $event = $events[37];
             $source = $event->getSource();
-            $this->assertTrue($source instanceof GroupSource);
+            $this->assertInstanceOf(GroupSource::class, $source);
             $this->assertEquals('groupid', $source->getGroupId());
             $this->assertEquals(null, $source->getUserId());
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
             $this->assertFalse($event->getDeliveryContext()->getIsRedelivery());
-            $this->assertJsonStringEqualsJsonString(json_encode($eventArrays[37]), $event->__toString());
+            $this->assertJsonStringEqualsJsonString(json_encode($eventArrays[37], JSON_THROW_ON_ERROR), $event->__toString());
             $this->assertInstanceOf(\LINE\Webhook\Model\MessageEvent::class, $event);
             $this->assertInstanceOf(\LINE\Webhook\Model\ImageMessageContent::class, $event->getMessage());
             $this->assertEquals('replytoken', $event->getReplyToken());
@@ -1639,10 +1645,10 @@ class EventRequestParserTest extends TestCase
             );
             $this->assertEquals(
                 'E005D41A7288F41B65593ED38FF6E9834B046AB36A37921A56BC236F13A91855',
-                $event->getMessage()->getImageSet()->getId()
+                $event->getMessage()->getImageSet()?->getId()
             );
-            $this->assertNull($event->getMessage()->getImageSet()->getIndex());
-            $this->assertNull($event->getMessage()->getImageSet()->getTotal());
+            $this->assertNull($event->getMessage()->getImageSet()?->getIndex());
+            $this->assertNull($event->getMessage()->getImageSet()?->getTotal());
         }
 
         {
@@ -1651,18 +1657,19 @@ class EventRequestParserTest extends TestCase
             $source = $event->getSource();
             $this->assertEquals(12345678901234, $event->getTimestamp());
             $this->assertEquals('active', $event->getMode());
-            $this->assertTrue($source instanceof UserSource);
+            $this->assertInstanceOf(UserSource::class, $source);
             $this->assertEquals('userid', $source->getUserId());
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
             $this->assertTrue($event->getDeliveryContext()->getIsRedelivery());
-            $this->assertJsonStringEqualsJsonString(json_encode($eventArrays[38]), $event->__toString());
+            $this->assertJsonStringEqualsJsonString(json_encode($eventArrays[38], JSON_THROW_ON_ERROR), $event->__toString());
             $this->assertInstanceOf(\LINE\Webhook\Model\MessageEvent::class, $event);
             $this->assertInstanceOf(\LINE\Webhook\Model\TextMessageContent::class, $event->getMessage());
             $this->assertEquals('replytoken', $event->getReplyToken());
             $this->assertEquals('contentid', $event->getMessage()->getId());
             $this->assertEquals('text', $event->getMessage()->getType());
             $this->assertEquals('message (love)', $event->getMessage()->getText());
-            $emojiInfo = $event->getMessage()->getEmojis()[0];
+            $emojiInfo = $event->getMessage()->getEmojis()[0] ?? null;
+            $this->assertInstanceOf(\LINE\Webhook\Model\Emoji::class, $emojiInfo);
             $this->assertEquals(8, $emojiInfo->getIndex());
             $this->assertEquals(6, $emojiInfo->getLength());
             $this->assertEquals('5ac1bfd5040ab15980c9b435', $emojiInfo->getProductId());
@@ -1675,7 +1682,7 @@ class EventRequestParserTest extends TestCase
             $source = $event->getSource();
             $this->assertEquals(12345678901234, $event->getTimestamp());
             $this->assertEquals('active', $event->getMode());
-            $this->assertTrue($source instanceof UserSource);
+            $this->assertInstanceOf(UserSource::class, $source);
             $this->assertEquals('userid', $source->getUserId());
             $this->assertInstanceOf(\LINE\Webhook\Model\ActivatedEvent::class, $event);
             $this->assertInstanceOf(\LINE\Webhook\Model\ChatControl::class, $event->getChatControl());
@@ -1690,7 +1697,7 @@ class EventRequestParserTest extends TestCase
             $source = $event->getSource();
             $this->assertEquals(12345678901234, $event->getTimestamp());
             $this->assertEquals('active', $event->getMode());
-            $this->assertTrue($source instanceof UserSource);
+            $this->assertInstanceOf(UserSource::class, $source);
             $this->assertEquals('userid', $source->getUserId());
             $this->assertInstanceOf(\LINE\Webhook\Model\DeactivatedEvent::class, $event);
             $this->assertEquals('testwebhookeventid', $event->getWebhookEventId());
@@ -1723,7 +1730,7 @@ class EventRequestParserTest extends TestCase
             $source = $event->getSource();
             $this->assertEquals(12345678901234, $event->getTimestamp());
             $this->assertEquals('active', $event->getMode());
-            $this->assertTrue($source instanceof UserSource);
+            $this->assertInstanceOf(UserSource::class, $source);
             $this->assertEquals('userid', $source->getUserId());
             $this->assertInstanceOf(\LINE\Webhook\Model\PnpDeliveryCompletionEvent::class, $event);
             $this->assertInstanceOf(\LINE\Webhook\Model\PnpDelivery::class, $event->getDelivery());
@@ -1770,7 +1777,7 @@ class EventRequestParserTest extends TestCase
             $source = $event->getSource();
             $this->assertEquals(12345678901234, $event->getTimestamp());
             $this->assertEquals('active', $event->getMode());
-            $this->assertTrue($source instanceof UserSource);
+            $this->assertInstanceOf(UserSource::class, $source);
             $this->assertEquals('userid', $source->getUserId());
             $this->assertInstanceOf(\LINE\Webhook\Model\MembershipEvent::class, $event);
             /** @var \LINE\Webhook\Model\JoinedMembershipContent $membership */
@@ -1790,7 +1797,7 @@ class EventRequestParserTest extends TestCase
             $source = $event->getSource();
             $this->assertEquals(12345678901234, $event->getTimestamp());
             $this->assertEquals('active', $event->getMode());
-            $this->assertTrue($source instanceof UserSource);
+            $this->assertInstanceOf(UserSource::class, $source);
             $this->assertEquals('userid', $source->getUserId());
             $this->assertInstanceOf(\LINE\Webhook\Model\MembershipEvent::class, $event);
             /** @var \LINE\Webhook\Model\LeftMembershipContent $membership */
@@ -1810,7 +1817,7 @@ class EventRequestParserTest extends TestCase
             $source = $event->getSource();
             $this->assertEquals(12345678901234, $event->getTimestamp());
             $this->assertEquals('active', $event->getMode());
-            $this->assertTrue($source instanceof UserSource);
+            $this->assertInstanceOf(UserSource::class, $source);
             $this->assertEquals('userid', $source->getUserId());
             $this->assertInstanceOf(\LINE\Webhook\Model\MembershipEvent::class, $event);
             /** @var \LINE\Webhook\Model\RenewedMembershipContent $membership */

--- a/src/parser/test/SignatureValidatorTest.php
+++ b/src/parser/test/SignatureValidatorTest.php
@@ -23,8 +23,8 @@ use PHPUnit\Framework\TestCase;
 
 class SignatureValidatorTest extends TestCase
 {
-    private static $channelSecret = 'testsecret';
-    private static $json = <<<JSON
+    private static string $channelSecret = 'testsecret';
+    private static string $json = <<<JSON
 {
  "events":[
   {
@@ -178,7 +178,7 @@ JSON;
     /**
      * @throws \LINE\Parser\Exception\InvalidSignatureException
      */
-    public function testValidateSignature()
+    public function testValidateSignature(): void
     {
         $this->assertTrue(SignatureValidator::validateSignature(
             self::$json,


### PR DESCRIPTION
Related #669 

PHPStan (static code analysis) allows you to choose the type of warnings based on levels.
https://phpstan.org/user-guide/rule-levels

It is currently set to level 5 (the maximum is 10). Let's make it stricter and refactor the code for better quality.

I've raised it to level 8 in this PR for now.