### PR TITLE
Fix EchoBot DI error to receive messages

### DIFF
--- a/examples/EchoBot/composer.json
+++ b/examples/EchoBot/composer.json
@@ -17,6 +17,15 @@
 	    "role": "Maintainer"
     }
   ],
+  "repositories": [
+    {
+      "type": "path",
+      "url": "../../",
+      "options": {
+        "symlink": false
+      }
+    }
+  ],
   "require": {
     "php": ">=8.1",
     "slim/slim": "^4.11",
@@ -25,8 +34,10 @@
     "monolog/monolog": "^3.0.0",
     "guzzlehttp/guzzle": "^7.5",
     "guzzlehttp/psr7": "^2.5",
-    "php-di/slim-bridge": "^3.3"
+    "php-di/slim-bridge": "^3.3",
+    "linecorp/line-bot-sdk": "*"
   },
+  "minimum-stability": "dev",
   "autoload": {
     "psr-4": {
       "LINE\\": "src/"

--- a/examples/EchoBot/src/LINEBot/EchoBot/Dependency.php
+++ b/examples/EchoBot/src/LINEBot/EchoBot/Dependency.php
@@ -38,7 +38,7 @@ class Dependency
             return $logger;
         });
 
-        $container->set('botMessagingApi', function ($c) {
+        $container->set(MessagingApiApi::class, function ($c) {
             $settings = $c->get('settings');
             $channelToken = $settings['bot']['channelToken'];
             $config = new Configuration();


### PR DESCRIPTION
Resolve #675 

I referred to KitchenSink.
https://github.com/line/line-bot-sdk-php/blob/2135b059c6e99c4e551ad3de1097e21ea1ec6f2e/examples/KitchenSink/src/LINEBot/KitchenSink/Dependency.php#L42
https://github.com/line/line-bot-sdk-php/blob/2135b059c6e99c4e551ad3de1097e21ea1ec6f2e/examples/KitchenSink/composer.json#L20-L40

I have fixed the correction of DI name (botMessagingApi -> MessagingApiApi::class) was missed in the past revisions.
In addition, classes in line-bot-sdk-php was used directly so I have fixed to be used via composer and we can use some classes like Configuration class.