### PR TITLE
Fix LocationMessageHandler to handle non title or address

### DIFF
--- a/examples/KitchenSink/src/LINEBot/KitchenSink/EventHandler/MessageHandler/LocationMessageHandler.php
+++ b/examples/KitchenSink/src/LINEBot/KitchenSink/EventHandler/MessageHandler/LocationMessageHandler.php
@@ -57,8 +57,8 @@ class LocationMessageHandler implements EventHandler
 
         $message = new LocationMessage([
             'type' => MessageType::LOCATION,
-            'title' => $this->locationMessage->getTitle(),
-            'address' => $this->locationMessage->getAddress(),
+            'title' => $this->locationMessage->getTitle() ?? "default title",
+            'address' => $this->locationMessage->getAddress() ?? "default address",
             'latitude' => $this->locationMessage->getLatitude(),
             'longitude' => $this->locationMessage->getLongitude(),
         ]);


### PR DESCRIPTION
Location Message Webhook sometimes does not have title or address.
https://developers.line.biz/en/reference/messaging-api/#wh-location

However, when Official Account sends Location Message, title and address is required.
https://developers.line.biz/en/reference/messaging-api/#location-message

So usually LocationMessageHandler is failed to send message.
```
POST /callback - Uncaught LINE\Clients\MessagingApi\ApiException: [400] Client error: `POST https://api.line.me/v2/bot/message/reply` resulted in a `400 Bad Request` response:
{"message":"The request body has 1 error(s)","details":[{"message":"May not be empty","property":"messages[0].title"}]}

```

I've added default value as title and address and fixed it.