### PR TITLE
Grant minimum permissions to github acitons workflow jobs

### DIFF
--- a/.github/workflows/check-eol-newrelease.yml
+++ b/.github/workflows/check-eol-newrelease.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   check-eol-newrelease:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/check-eol-newrelease.yml
+++ b/.github/workflows/check-eol-newrelease.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+    if: github.repository == 'line/line-bot-sdk-php'
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+    if: github.repository == 'line/line-bot-sdk-php'
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   validate-input:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Validate Acknowledgement
         if: ${{ github.event.inputs.acknowledge_draft != 'Yes' }}
@@ -41,12 +42,13 @@ jobs:
   create-draft-release:
     runs-on: ubuntu-latest
     needs: validate-input
-
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Fetch Latest Release
         id: get-latest-release
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const latestRelease = await github.rest.repos.getLatestRelease({
@@ -62,7 +64,7 @@ jobs:
 
       - name: Calculate New Version
         id: calculate-version
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const latestTag = '${{ steps.get-latest-release.outputs.latest_tag }}';
@@ -83,7 +85,7 @@ jobs:
 
       - name: Generate Release Notes
         id: generate-release-notes
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const { data: releaseNotes } = await github.rest.repos.generateReleaseNotes({

--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -12,7 +12,9 @@ jobs:
   tests:
     name: Generate OpenAPI based code
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       # Setup
       - uses: actions/checkout@v4

--- a/.github/workflows/php-checks.yml
+++ b/.github/workflows/php-checks.yml
@@ -9,6 +9,8 @@ jobs:
   tests:
     name: Run checks on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,19 +5,11 @@ on:
     types: [ published ]
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
-
 
 jobs:
   # Single deploy job since we're just deploying
@@ -26,6 +18,11 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,3 +35,21 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      - name: Create GitHub Issue on Failure
+        if: failure()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issueTitle = `deploy-page job failed`;
+            const issueBody = `The deploy-page job failed. Please check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.`;
+            const assignees = [context.actor];
+
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title: issueTitle,
+              body: issueBody,
+              assignees
+            });


### PR DESCRIPTION
## Changes
Granting the minimum necessary permissions is always a good practice. There might be cases where permissions are insufficient, but since errors are very clear, I believe we can add them when a failure occurs.

After merging, I will change the default of the GITHUB_ACTIONS token from read + write to read only. Then, I will run as many workflows as possible (including publish) to verify their operation.

reference: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token#overview