### PR TITLE
Require more jobs in merge queue

### DIFF
--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -1,12 +1,10 @@
 name: Generate code and open pull request
 
 on:
-  workflow_dispatch:
   push:
-    branches:
-      - master
   pull_request:
   merge_group:
+  workflow_dispatch:
 
 jobs:
   tests:

--- a/.github/workflows/php-checks.yml
+++ b/.github/workflows/php-checks.yml
@@ -4,6 +4,7 @@ on:
   push:
   pull_request:
   merge_group:
+  workflow_dispatch:
 
 jobs:
   tests:


### PR DESCRIPTION
To re-enable the merge queue, this change adds merge_group to several jobs.

original: https://github.com/line/line-bot-sdk-java/pull/1592