### PR TITLE
Support PHP 8.5

### DIFF
--- a/.github/workflows/php-checks.yml
+++ b/.github/workflows/php-checks.yml
@@ -15,7 +15,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
+        php: 
+          - 8.1
+          - 8.2
+          - 8.3
+          - 8.4
+          - 8.5
         include:
           - php: 8.1
             analysis: true
@@ -24,6 +29,8 @@ jobs:
           - php: 8.3
             analysis: true
           - php: 8.4
+            analysis: true
+          - php: 8.5
             analysis: true
 
     steps:


### PR DESCRIPTION
Resolve https://github.com/line/line-bot-sdk-php/issues/759

To support PHP 8.5, I've added tests for PHP 8.5.

## TODO

- [x] Add Run checks on PHP 8.5 CI as required to Settings