### PR TITLE
Revert "chore(deps): update dependency org.openapitools:openapi-generator-cli to v7.22.0"

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -38,6 +38,6 @@
     </build>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <openapi-generator-version>7.22.0</openapi-generator-version>
+        <openapi-generator-version>7.11.0</openapi-generator-version>
     </properties>
 </project>


### PR DESCRIPTION
Reverts line/line-bot-sdk-php#810


https://github.com/line/line-bot-sdk-php/pull/823 should handle this, and we should not keep current status. Every commits hooks new PRs like https://github.com/line/line-bot-sdk-php/pull/829 https://github.com/line/line-bot-sdk-php/pull/827 https://github.com/line/line-bot-sdk-php/pull/831