### PR TITLE
NO-ISSUE: Pin behavioral contract of generated clients ahead of openapi-generator 7.22.0

### DIFF
--- a/test/clients/insight/Api/InsightApiTest.php
+++ b/test/clients/insight/Api/InsightApiTest.php
@@ -1,0 +1,225 @@
+<?php
+
+/**
+ * Copyright 2026 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace LINE\Tests\Clients\Insight\Api;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Query;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use LINE\Clients\Insight\Api\InsightApi;
+use LINE\Clients\Insight\Model\GetFriendsDemographicsResponse;
+use LINE\Clients\Insight\Model\GetMessageEventResponse;
+use LINE\Clients\Insight\Model\GetNumberOfFollowersResponse;
+use LINE\Clients\Insight\Model\GetNumberOfMessageDeliveriesResponse;
+use LINE\Clients\Insight\Model\GetStatisticsPerUnitResponse;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Characterization tests for the auto-generated InsightApi client.
+ *
+ * These tests pin the request shape (HTTP method, URL path and query parameter
+ * keys) that the OpenAPI generator currently produces. They are intentionally
+ * strict about query keys so that a future openapi-generator bump that changes
+ * the serialization (e.g. camelCase vs snake_case, like the form-param
+ * regression fixed in #810/#823) is caught before release.
+ */
+class InsightApiTest extends TestCase
+{
+    private function assertQueryEquals(array $expected, UriInterface $uri): void
+    {
+        $this->assertSame($expected, Query::parse($uri->getQuery()), 'Query parameters mismatch');
+    }
+
+    public function testGetFriendsDemographics(): void
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('send')
+            ->with(
+                Mockery::on(function (Request $request) {
+                    $this->assertEquals('GET', $request->getMethod());
+                    $this->assertEquals(
+                        'https://api.line.me/v2/bot/insight/demographic',
+                        (string)$request->getUri()
+                    );
+                    return true;
+                }),
+                []
+            )
+            ->once()
+            ->andReturn(new Response(
+                status: 200,
+                headers: [],
+                body: json_encode(['available' => true, 'genders' => []]),
+            ));
+        $api = new InsightApi($client);
+        $response = $api->getFriendsDemographics();
+        $this->assertInstanceOf(GetFriendsDemographicsResponse::class, $response);
+        $this->assertTrue($response->getAvailable());
+    }
+
+    public function testGetNumberOfFollowers(): void
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('send')
+            ->with(
+                Mockery::on(function (Request $request) {
+                    $this->assertEquals('GET', $request->getMethod());
+                    $uri = $request->getUri();
+                    $this->assertEquals('/v2/bot/insight/followers', $uri->getPath());
+                    $this->assertQueryEquals(['date' => '20260601'], $uri);
+                    return true;
+                }),
+                []
+            )
+            ->once()
+            ->andReturn(new Response(
+                status: 200,
+                headers: [],
+                body: json_encode([
+                    'status' => 'ready',
+                    'followers' => 100,
+                    'targetedReaches' => 90,
+                    'blocks' => 5,
+                ]),
+            ));
+        $api = new InsightApi($client);
+        $response = $api->getNumberOfFollowers(date: '20260601');
+        $this->assertInstanceOf(GetNumberOfFollowersResponse::class, $response);
+        $this->assertEquals('ready', $response->getStatus());
+        $this->assertEquals(100, $response->getFollowers());
+        $this->assertEquals(5, $response->getBlocks());
+    }
+
+    public function testGetNumberOfMessageDeliveries(): void
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('send')
+            ->with(
+                Mockery::on(function (Request $request) {
+                    $this->assertEquals('GET', $request->getMethod());
+                    $uri = $request->getUri();
+                    $this->assertEquals('/v2/bot/insight/message/delivery', $uri->getPath());
+                    $this->assertQueryEquals(['date' => '20260601'], $uri);
+                    return true;
+                }),
+                []
+            )
+            ->once()
+            ->andReturn(new Response(
+                status: 200,
+                headers: [],
+                body: json_encode(['status' => 'ready', 'broadcast' => 50]),
+            ));
+        $api = new InsightApi($client);
+        $response = $api->getNumberOfMessageDeliveries(date: '20260601');
+        $this->assertInstanceOf(GetNumberOfMessageDeliveriesResponse::class, $response);
+        $this->assertEquals('ready', $response->getStatus());
+        $this->assertEquals(50, $response->getBroadcast());
+    }
+
+    public function testGetMessageEvent(): void
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('send')
+            ->with(
+                Mockery::on(function (Request $request) {
+                    $this->assertEquals('GET', $request->getMethod());
+                    $uri = $request->getUri();
+                    $this->assertEquals('/v2/bot/insight/message/event', $uri->getPath());
+                    // The LINE Insight API uses the camelCase "requestId" query key.
+                    $this->assertQueryEquals(['requestId' => 'abcdef'], $uri);
+                    return true;
+                }),
+                []
+            )
+            ->once()
+            ->andReturn(new Response(
+                status: 200,
+                headers: [],
+                body: json_encode(['overview' => ['requestId' => 'abcdef']]),
+            ));
+        $api = new InsightApi($client);
+        $response = $api->getMessageEvent(requestId: 'abcdef');
+        $this->assertInstanceOf(GetMessageEventResponse::class, $response);
+    }
+
+    public function testGetStatisticsPerUnit(): void
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('send')
+            ->with(
+                Mockery::on(function (Request $request) {
+                    $this->assertEquals('GET', $request->getMethod());
+                    $uri = $request->getUri();
+                    $this->assertEquals('/v2/bot/insight/message/event/aggregation', $uri->getPath());
+                    // All three query keys are camelCase in the spec and must be preserved.
+                    $this->assertQueryEquals([
+                        'customAggregationUnit' => 'promotion_a',
+                        'from' => '20260601',
+                        'to' => '20260630',
+                    ], $uri);
+                    return true;
+                }),
+                []
+            )
+            ->once()
+            ->andReturn(new Response(
+                status: 200,
+                headers: [],
+                body: json_encode(['overview' => [], 'messages' => [], 'clicks' => []]),
+            ));
+        $api = new InsightApi($client);
+        $response = $api->getStatisticsPerUnit(
+            customAggregationUnit: 'promotion_a',
+            from: '20260601',
+            to: '20260630',
+        );
+        $this->assertInstanceOf(GetStatisticsPerUnitResponse::class, $response);
+    }
+
+    public function testGetStatisticsPerUnitRejectsInvalidUnit(): void
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $api = new InsightApi($client);
+        $this->expectException(\InvalidArgumentException::class);
+        // "customAggregationUnit" must match /^[a-zA-Z0-9_]{1,30}$/.
+        $api->getStatisticsPerUnit(
+            customAggregationUnit: 'invalid unit!',
+            from: '20260601',
+            to: '20260630',
+        );
+    }
+
+    public function testGetNumberOfMessageDeliveriesRejectsInvalidDate(): void
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $api = new InsightApi($client);
+        $this->expectException(\InvalidArgumentException::class);
+        // "date" must match /^[0-9]{8}$/.
+        $api->getNumberOfMessageDeliveries(date: '2026-06-01');
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}

--- a/test/clients/insight/Api/InsightApiTest.php
+++ b/test/clients/insight/Api/InsightApiTest.php
@@ -195,6 +195,24 @@ class InsightApiTest extends TestCase
         $this->assertInstanceOf(GetStatisticsPerUnitResponse::class, $response);
     }
 
+    public function testThrowsApiExceptionOnMalformedJsonResponse(): void
+    {
+        // The 7.22.0 regeneration extracts response handling into
+        // handleResponseWithDataType(); this pins the invariant that a 2xx
+        // response with an undecodable body still surfaces as an ApiException.
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('send')
+            ->once()
+            ->andReturn(new Response(
+                status: 200,
+                headers: [],
+                body: 'this is not valid json {',
+            ));
+        $api = new InsightApi($client);
+        $this->expectException(\LINE\Clients\Insight\ApiException::class);
+        $api->getNumberOfFollowers(date: '20260601');
+    }
+
     public function testGetStatisticsPerUnitRejectsInvalidUnit(): void
     {
         $client = Mockery::mock(ClientInterface::class);

--- a/test/clients/liff/Api/LiffApiTest.php
+++ b/test/clients/liff/Api/LiffApiTest.php
@@ -151,6 +151,23 @@ class LiffApiTest extends TestCase
         $api->deleteLIFFApp('1234567890-AbcdEfgh');
     }
 
+    public function testThrowsApiExceptionOnMalformedJsonResponse(): void
+    {
+        // Pins the response-handling invariant that the 7.22.0 regeneration
+        // refactors into handleResponseWithDataType().
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('send')
+            ->once()
+            ->andReturn(new Response(
+                status: 200,
+                headers: [],
+                body: 'this is not valid json {',
+            ));
+        $api = new LiffApi($client);
+        $this->expectException(\LINE\Clients\Liff\ApiException::class);
+        $api->getAllLIFFApps();
+    }
+
     protected function tearDown(): void
     {
         Mockery::close();

--- a/test/clients/liff/Api/LiffApiTest.php
+++ b/test/clients/liff/Api/LiffApiTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * Copyright 2026 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace LINE\Tests\Clients\Liff\Api;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use LINE\Clients\Liff\Api\LiffApi;
+use LINE\Clients\Liff\Model\AddLiffAppRequest;
+use LINE\Clients\Liff\Model\AddLiffAppResponse;
+use LINE\Clients\Liff\Model\GetAllLiffAppsResponse;
+use LINE\Clients\Liff\Model\UpdateLiffAppRequest;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Characterization tests for the auto-generated LiffApi client.
+ *
+ * They pin the HTTP method, the resource path (including path-parameter
+ * substitution) and the JSON body keys produced by ObjectSerializer, so that an
+ * openapi-generator update which changes request building is caught early.
+ */
+class LiffApiTest extends TestCase
+{
+    public function testAddLIFFApp(): void
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('send')
+            ->with(
+                Mockery::on(function (Request $request) {
+                    $this->assertEquals('POST', $request->getMethod());
+                    $this->assertEquals('https://api.line.me/liff/v1/apps', (string)$request->getUri());
+                    $body = json_decode((string)$request->getBody(), true);
+                    // attributeMap keys are kept as-is (camelCase) in the JSON body.
+                    $this->assertSame('https://example.com/liff', $body['view']['url']);
+                    $this->assertSame('full', $body['view']['type']);
+                    $this->assertSame('my liff app', $body['description']);
+                    return true;
+                }),
+                []
+            )
+            ->once()
+            ->andReturn(new Response(
+                status: 200,
+                headers: [],
+                body: json_encode(['liffId' => '1234567890-AbcdEfgh']),
+            ));
+        $api = new LiffApi($client);
+        $request = new AddLiffAppRequest([
+            'view' => ['type' => 'full', 'url' => 'https://example.com/liff'],
+            'description' => 'my liff app',
+        ]);
+        $response = $api->addLIFFApp($request);
+        $this->assertInstanceOf(AddLiffAppResponse::class, $response);
+        $this->assertEquals('1234567890-AbcdEfgh', $response->getLiffId());
+    }
+
+    public function testGetAllLIFFApps(): void
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('send')
+            ->with(
+                Mockery::on(function (Request $request) {
+                    $this->assertEquals('GET', $request->getMethod());
+                    $this->assertEquals('https://api.line.me/liff/v1/apps', (string)$request->getUri());
+                    $this->assertEquals('', (string)$request->getBody());
+                    return true;
+                }),
+                []
+            )
+            ->once()
+            ->andReturn(new Response(
+                status: 200,
+                headers: [],
+                body: json_encode([
+                    'apps' => [
+                        [
+                            'liffId' => '1234567890-AbcdEfgh',
+                            'view' => ['type' => 'full', 'url' => 'https://example.com/liff'],
+                        ],
+                    ],
+                ]),
+            ));
+        $api = new LiffApi($client);
+        $response = $api->getAllLIFFApps();
+        $this->assertInstanceOf(GetAllLiffAppsResponse::class, $response);
+        $apps = $response->getApps();
+        $this->assertCount(1, $apps);
+        $this->assertEquals('1234567890-AbcdEfgh', $apps[0]->getLiffId());
+    }
+
+    public function testUpdateLIFFAppSubstitutesPathParameter(): void
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('send')
+            ->with(
+                Mockery::on(function (Request $request) {
+                    $this->assertEquals('PUT', $request->getMethod());
+                    // The {liffId} path placeholder must be url-encoded and substituted.
+                    $this->assertEquals(
+                        'https://api.line.me/liff/v1/apps/1234567890-AbcdEfgh',
+                        (string)$request->getUri()
+                    );
+                    $body = json_decode((string)$request->getBody(), true);
+                    $this->assertSame('updated description', $body['description']);
+                    return true;
+                }),
+                []
+            )
+            ->once()
+            ->andReturn(new Response(status: 200, headers: [], body: ''));
+        $api = new LiffApi($client);
+        $request = new UpdateLiffAppRequest(['description' => 'updated description']);
+        $api->updateLIFFApp('1234567890-AbcdEfgh', $request);
+    }
+
+    public function testDeleteLIFFAppSubstitutesPathParameter(): void
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('send')
+            ->with(
+                Mockery::on(function (Request $request) {
+                    $this->assertEquals('DELETE', $request->getMethod());
+                    $this->assertEquals(
+                        'https://api.line.me/liff/v1/apps/1234567890-AbcdEfgh',
+                        (string)$request->getUri()
+                    );
+                    return true;
+                }),
+                []
+            )
+            ->once()
+            ->andReturn(new Response(status: 200, headers: [], body: ''));
+        $api = new LiffApi($client);
+        $api->deleteLIFFApp('1234567890-AbcdEfgh');
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}

--- a/test/clients/manage-audience/Api/ManageAudienceApiTest.php
+++ b/test/clients/manage-audience/Api/ManageAudienceApiTest.php
@@ -164,6 +164,23 @@ class ManageAudienceApiTest extends TestCase
         $api->updateAudienceGroupDescription(12345, $request);
     }
 
+    public function testThrowsApiExceptionOnMalformedJsonResponse(): void
+    {
+        // Pins the response-handling invariant that the 7.22.0 regeneration
+        // refactors into handleResponseWithDataType().
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('send')
+            ->once()
+            ->andReturn(new Response(
+                status: 200,
+                headers: [],
+                body: 'this is not valid json {',
+            ));
+        $api = new ManageAudienceApi($client);
+        $this->expectException(\LINE\Clients\ManageAudience\ApiException::class);
+        $api->getAudienceGroups(page: 1);
+    }
+
     protected function tearDown(): void
     {
         Mockery::close();

--- a/test/clients/manage-audience/Api/ManageAudienceApiTest.php
+++ b/test/clients/manage-audience/Api/ManageAudienceApiTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * Copyright 2026 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace LINE\Tests\Clients\ManageAudience\Api;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Query;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use LINE\Clients\ManageAudience\Api\ManageAudienceApi;
+use LINE\Clients\ManageAudience\Model\CreateAudienceGroupRequest;
+use LINE\Clients\ManageAudience\Model\CreateAudienceGroupResponse;
+use LINE\Clients\ManageAudience\Model\GetAudienceGroupsResponse;
+use LINE\Clients\ManageAudience\Model\UpdateAudienceGroupDescriptionRequest;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Characterization tests for the auto-generated ManageAudienceApi client.
+ *
+ * They pin the request shape (method, path, query keys and JSON body keys) so a
+ * future openapi-generator update that alters serialization is caught early.
+ */
+class ManageAudienceApiTest extends TestCase
+{
+    private function assertQueryEquals(array $expected, UriInterface $uri): void
+    {
+        $this->assertSame($expected, Query::parse($uri->getQuery()), 'Query parameters mismatch');
+    }
+
+    public function testCreateAudienceGroup(): void
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('send')
+            ->with(
+                Mockery::on(function (Request $request) {
+                    $this->assertEquals('POST', $request->getMethod());
+                    $this->assertEquals(
+                        'https://api.line.me/v2/bot/audienceGroup/upload',
+                        (string)$request->getUri()
+                    );
+                    $body = json_decode((string)$request->getBody(), true);
+                    // camelCase attributeMap keys must be preserved in the JSON body.
+                    $this->assertSame('test audience', $body['description']);
+                    $this->assertFalse($body['isIfaAudience']);
+                    $this->assertSame('upload', $body['uploadDescription']);
+                    return true;
+                }),
+                []
+            )
+            ->once()
+            ->andReturn(new Response(
+                status: 200,
+                headers: [],
+                body: json_encode([
+                    'audienceGroupId' => 12345,
+                    'type' => 'UPLOAD',
+                    'description' => 'test audience',
+                ]),
+            ));
+        $api = new ManageAudienceApi($client);
+        $request = new CreateAudienceGroupRequest([
+            'description' => 'test audience',
+            'isIfaAudience' => false,
+            'uploadDescription' => 'upload',
+        ]);
+        $response = $api->createAudienceGroup($request);
+        $this->assertInstanceOf(CreateAudienceGroupResponse::class, $response);
+        $this->assertEquals(12345, $response->getAudienceGroupId());
+    }
+
+    public function testGetAudienceGroups(): void
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('send')
+            ->with(
+                Mockery::on(function (Request $request) {
+                    $this->assertEquals('GET', $request->getMethod());
+                    $uri = $request->getUri();
+                    $this->assertEquals('/v2/bot/audienceGroup/list', $uri->getPath());
+                    // Only the required "page" parameter is sent; optional null params are omitted.
+                    $this->assertQueryEquals(['page' => '1'], $uri);
+                    return true;
+                }),
+                []
+            )
+            ->once()
+            ->andReturn(new Response(
+                status: 200,
+                headers: [],
+                body: json_encode([
+                    'audienceGroups' => [],
+                    'hasNextPage' => false,
+                    'totalCount' => 0,
+                    'page' => 1,
+                    'size' => 20,
+                ]),
+            ));
+        $api = new ManageAudienceApi($client);
+        $response = $api->getAudienceGroups(page: 1);
+        $this->assertInstanceOf(GetAudienceGroupsResponse::class, $response);
+        $this->assertFalse($response->getHasNextPage());
+        $this->assertEquals(0, $response->getTotalCount());
+    }
+
+    public function testDeleteAudienceGroupSubstitutesPathParameter(): void
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('send')
+            ->with(
+                Mockery::on(function (Request $request) {
+                    $this->assertEquals('DELETE', $request->getMethod());
+                    $this->assertEquals(
+                        'https://api.line.me/v2/bot/audienceGroup/12345',
+                        (string)$request->getUri()
+                    );
+                    return true;
+                }),
+                []
+            )
+            ->once()
+            ->andReturn(new Response(status: 200, headers: [], body: ''));
+        $api = new ManageAudienceApi($client);
+        $api->deleteAudienceGroup(12345);
+    }
+
+    public function testUpdateAudienceGroupDescription(): void
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('send')
+            ->with(
+                Mockery::on(function (Request $request) {
+                    $this->assertEquals('PUT', $request->getMethod());
+                    $this->assertEquals(
+                        'https://api.line.me/v2/bot/audienceGroup/12345/updateDescription',
+                        (string)$request->getUri()
+                    );
+                    $body = json_decode((string)$request->getBody(), true);
+                    $this->assertSame('new description', $body['description']);
+                    return true;
+                }),
+                []
+            )
+            ->once()
+            ->andReturn(new Response(status: 200, headers: [], body: ''));
+        $api = new ManageAudienceApi($client);
+        $request = new UpdateAudienceGroupDescriptionRequest(['description' => 'new description']);
+        $api->updateAudienceGroupDescription(12345, $request);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}

--- a/test/clients/messaging-api/ObjectSerializerTest.php
+++ b/test/clients/messaging-api/ObjectSerializerTest.php
@@ -1,0 +1,220 @@
+<?php
+
+/**
+ * Copyright 2026 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace LINE\Tests\Clients\MessagingApi;
+
+use LINE\Clients\MessagingApi\Model\TextMessage;
+use LINE\Clients\MessagingApi\ObjectSerializer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the auto-generated ObjectSerializer.
+ *
+ * ObjectSerializer is the shared serialization helper that EVERY generated
+ * client copy relies on (request bodies, query strings, response parsing). It is
+ * fully owned by the OpenAPI generator and is rewritten on every bump, so these
+ * tests pin its observable behavior as a safety net for generator updates.
+ * The MessagingApi copy is used as the representative; all client copies share
+ * the same template.
+ */
+class ObjectSerializerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Reset shared static state so tests are independent.
+        ObjectSerializer::setDateTimeFormat(\DateTime::ATOM);
+    }
+
+    protected function tearDown(): void
+    {
+        ObjectSerializer::setDateTimeFormat(\DateTime::ATOM);
+        parent::tearDown();
+    }
+
+    public function testSanitizeForSerializationPassesScalarsAndNull(): void
+    {
+        $this->assertSame('text', ObjectSerializer::sanitizeForSerialization('text'));
+        $this->assertSame(42, ObjectSerializer::sanitizeForSerialization(42));
+        $this->assertTrue(ObjectSerializer::sanitizeForSerialization(true));
+        $this->assertNull(ObjectSerializer::sanitizeForSerialization(null));
+    }
+
+    public function testSanitizeForSerializationFormatsDateTime(): void
+    {
+        $dateTime = new \DateTime('2026-06-01T10:30:00+00:00');
+        $this->assertSame(
+            '2026-06-01',
+            ObjectSerializer::sanitizeForSerialization($dateTime, '\DateTime', 'date')
+        );
+        $this->assertSame(
+            '2026-06-01T10:30:00+00:00',
+            ObjectSerializer::sanitizeForSerialization($dateTime, '\DateTime', 'date-time')
+        );
+    }
+
+    public function testSanitizeForSerializationRecursesIntoArrays(): void
+    {
+        $dateTime = new \DateTime('2026-06-01T10:30:00+00:00');
+        $result = ObjectSerializer::sanitizeForSerialization(['a' => 1, 'when' => $dateTime]);
+        $this->assertSame(1, $result['a']);
+        $this->assertSame('2026-06-01T10:30:00+00:00', $result['when']);
+    }
+
+    public function testSanitizeForSerializationUsesModelAttributeMapKeys(): void
+    {
+        $message = new TextMessage(['text' => 'hello']);
+        $serialized = ObjectSerializer::sanitizeForSerialization($message);
+        // The discriminator and attributeMap keys must be present, unset fields omitted.
+        $this->assertSame('text', $serialized->type);
+        $this->assertSame('hello', $serialized->text);
+        $this->assertObjectNotHasProperty('quoteToken', $serialized);
+        $this->assertObjectNotHasProperty('emojis', $serialized);
+    }
+
+    public function testSanitizeFilename(): void
+    {
+        $this->assertSame('sun.gif', ObjectSerializer::sanitizeFilename('../../sun.gif'));
+        $this->assertSame('sun.gif', ObjectSerializer::sanitizeFilename('/var/tmp/sun.gif'));
+        $this->assertSame('sun.gif', ObjectSerializer::sanitizeFilename('C:\\images\\sun.gif'));
+        $this->assertSame('plain.txt', ObjectSerializer::sanitizeFilename('plain.txt'));
+    }
+
+    public function testToPathValueUrlEncodes(): void
+    {
+        $this->assertSame('a%2Fb%20c', ObjectSerializer::toPathValue('a/b c'));
+        $this->assertSame('1234567890-AbcdEfgh', ObjectSerializer::toPathValue('1234567890-AbcdEfgh'));
+    }
+
+    public function testToStringHandlesTypes(): void
+    {
+        $this->assertSame('true', ObjectSerializer::toString(true));
+        $this->assertSame('false', ObjectSerializer::toString(false));
+        $this->assertSame('5', ObjectSerializer::toString(5));
+        $this->assertSame(
+            '2026-06-01T10:30:00+00:00',
+            ObjectSerializer::toString(new \DateTime('2026-06-01T10:30:00+00:00'))
+        );
+    }
+
+    public function testToFormValuePassesThroughString(): void
+    {
+        $this->assertSame('value', ObjectSerializer::toFormValue('value'));
+    }
+
+    public function testToQueryValueRequiredEmptyKeepsEmptyKey(): void
+    {
+        $this->assertSame(['name' => ''], ObjectSerializer::toQueryValue(null, 'name', 'string', 'form', true, true));
+    }
+
+    public function testToQueryValueOptionalEmptyIsOmitted(): void
+    {
+        $this->assertSame([], ObjectSerializer::toQueryValue(null, 'name', 'string', 'form', true, false));
+        $this->assertSame([], ObjectSerializer::toQueryValue('', 'name', 'string', 'form', true, false));
+    }
+
+    public function testToQueryValueZeroIntIsNotEmpty(): void
+    {
+        // 0 is a meaningful value for an int parameter and must be kept.
+        $this->assertSame(['count' => 0], ObjectSerializer::toQueryValue(0, 'count', 'integer', 'form', true, false));
+    }
+
+    public function testToQueryValueScalar(): void
+    {
+        $this->assertSame(['date' => '20260601'], ObjectSerializer::toQueryValue('20260601', 'date'));
+    }
+
+    public function testToQueryValueArrayExplode(): void
+    {
+        $this->assertSame(
+            ['ids' => ['a', 'b']],
+            ObjectSerializer::toQueryValue(['a', 'b'], 'ids', 'array', 'form', true, true)
+        );
+    }
+
+    public function testConvertBoolToQueryStringFormatUsesIntByDefault(): void
+    {
+        $this->assertSame(1, ObjectSerializer::convertBoolToQueryStringFormat(true));
+        $this->assertSame(0, ObjectSerializer::convertBoolToQueryStringFormat(false));
+    }
+
+    public function testBuildQuery(): void
+    {
+        $this->assertSame('', ObjectSerializer::buildQuery([]));
+        $this->assertSame('a=b&c=d', ObjectSerializer::buildQuery(['a' => 'b', 'c' => 'd']));
+        // Repeated keys for list values (no [] index appended).
+        $this->assertSame('k=1&k=2', ObjectSerializer::buildQuery(['k' => ['1', '2']]));
+        // RFC3986 encoding of reserved characters.
+        $this->assertSame('a=b%20c', ObjectSerializer::buildQuery(['a' => 'b c']));
+        // Booleans use the integer format by default.
+        $this->assertSame('flag=1', ObjectSerializer::buildQuery(['flag' => true]));
+    }
+
+    public function testSerializeCollection(): void
+    {
+        $items = ['a', 'b', 'c'];
+        $this->assertSame('a,b,c', ObjectSerializer::serializeCollection($items, 'csv'));
+        $this->assertSame('a|b|c', ObjectSerializer::serializeCollection($items, 'pipes'));
+        $this->assertSame('a b c', ObjectSerializer::serializeCollection($items, 'ssv'));
+        $this->assertSame("a\tb\tc", ObjectSerializer::serializeCollection($items, 'tsv'));
+        // Unknown style falls back to CSV.
+        $this->assertSame('a,b,c', ObjectSerializer::serializeCollection($items, 'unknown'));
+    }
+
+    public function testDeserializeNullReturnsNull(): void
+    {
+        $this->assertNull(ObjectSerializer::deserialize(null, TextMessage::class));
+    }
+
+    public function testDeserializePrimitive(): void
+    {
+        $this->assertSame(5, ObjectSerializer::deserialize('5', 'int'));
+        $this->assertSame('hello', ObjectSerializer::deserialize('hello', 'string'));
+    }
+
+    public function testDeserializeDateTime(): void
+    {
+        $result = ObjectSerializer::deserialize('2026-06-01T10:30:00+00:00', '\DateTime');
+        $this->assertInstanceOf(\DateTime::class, $result);
+        $this->assertSame('2026-06-01T10:30:00+00:00', $result->format(\DateTime::ATOM));
+    }
+
+    public function testDeserializeEmptyDateTimeReturnsNull(): void
+    {
+        $this->assertNull(ObjectSerializer::deserialize('', '\DateTime'));
+    }
+
+    public function testDeserializeModelUsesAttributeMap(): void
+    {
+        $message = ObjectSerializer::deserialize('{"type":"text","text":"hello"}', TextMessage::class);
+        $this->assertInstanceOf(TextMessage::class, $message);
+        $this->assertSame('hello', $message->getText());
+    }
+
+    public function testDeserializeArrayOfModels(): void
+    {
+        $messages = ObjectSerializer::deserialize(
+            '[{"type":"text","text":"a"},{"type":"text","text":"b"}]',
+            TextMessage::class . '[]'
+        );
+        $this->assertIsArray($messages);
+        $this->assertCount(2, $messages);
+        $this->assertSame('a', $messages[0]->getText());
+        $this->assertSame('b', $messages[1]->getText());
+    }
+}


### PR DESCRIPTION
## Background

When `openapi-generator` is bumped (7.11.0 -> 7.22.0) and the clients are regenerated, the generated code under `src/clients/*/lib/` and `src/webhook/lib/` changes. This PR adds tests that **pin the observable behavior of the parts that get rewritten**, so the regeneration can be reviewed/merged with confidence (same spirit as #810 / #823, which are prepared separately).

I verified the exact diff by actually regenerating with 7.22.0 locally. The behaviorally-relevant changes are:

- **Api classes**: per-operation response parsing is extracted into a shared `handleResponseWithDataType()` helper; the `catch (ApiException)` 200 branch changes `break;` -> `throw $e;`.
- **Api classes**: `createHttpClientOption()` gains **mTLS** support (`RequestOptions::CERT` / `SSL_KEY`).
- **Configuration**: new `certFile` / `keyFile` properties + getters/setters (mTLS).
- **`FormDataProcessor`**: new generated class (used by the form-based ChannelAccessToken endpoints).
- **Model / ObjectSerializer**: diff is **comment-only** (`Generator version` / `PHP version` doc strings) — not executable.

## What this PR covers (pre-mergeable on the current code)

These tests pass on **both** the current generated code (7.11.0) **and** the regenerated code (7.22.0), so they can land ahead of the bump and then guard it:

- `InsightApi`, `LiffApi`, `ManageAudienceApi`: request shape (method / path / query keys / JSON body keys) + response deserialization.
- Response-handling invariant: a 2xx response with an undecodable body still raises `ApiException` (this is exactly the code path the `handleResponseWithDataType()` extraction refactors).
- `ObjectSerializer`: unit tests for the shared serialization helper (regenerated, behavior-identical).

## Honest scope note — this does NOT make the regeneration diff 100% covered

Two parts of the diff cannot be covered by an advance, test-only PR:

1. **mTLS (`RequestOptions::CERT` / `SSL_KEY`, `Configuration::set/getCertFile/KeyFile`)** — this is **new functionality** that does not exist on the current code, so a test referencing it cannot compile/run until the regeneration lands. It must be tested **together with** the regenerated code (i.e. in the generator-bump PR).
2. **`responseWithinRangeCode()`** — generated by 7.22.0 but **never called** (dead code), so it is unreachable by any test.

Measured on the regenerated 7.22.0 code: `handleResponseWithDataType()` is covered (happy path + JSON-error path); the mTLS lines and `responseWithinRangeCode()` are not.

## Test plan

- [x] `composer test` passes on current code (63 tests)
- [x] `composer test` passes on locally-regenerated 7.22.0 code (63 tests)
- [x] `composer cs` / `composer copyright` pass
- [ ] mTLS tests to be added in the generator-bump PR (depends on regenerated code)