### PR TITLE
Use composer check in test job, instead of specifying some commands

### DIFF
--- a/.github/workflows/php-checks.yml
+++ b/.github/workflows/php-checks.yml
@@ -48,40 +48,12 @@ jobs:
       - name: Generate code
         run: python generate-code.py
 
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php }}-
-
       - name: Install dependencies with Composer
         uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
-      - name: Check copyrights
+      - name: Run all checks
         if: matrix.analysis
-        run: composer copyright
-
-      - name: Check code style with PHP_CodeSniffer
-        if: matrix.analysis
-        run: composer cs
-
-      - name: Check with PHP Mess Detector 
-        if: matrix.analysis
-        run: composer md
-
-      - name: Check with PHPStan
-        if: matrix.analysis
-        run: composer stan
-
-      - name: Run unit tests
-        if: matrix.analysis
-        run: composer test
+        run: composer check
 
   pinact:
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -49,17 +49,23 @@
   "scripts": {
     "test": "phpunit --test-suffix=Test.php --testdox",
     "cs": "phpcs",
-    "md": "phpmd --ignore-violations-on-exit src/constants,src/laravel,src/parser,examples/EchoBot/src,examples/EchoBot/public,examples/KitchenSink/src,examples/KitchenSink/public text phpmd.xml",
+    "md": "tools/phpmd.sh",
     "stan": "phpstan analyse",
-    "lint": "find src/clients examples -name '*.php' -print0 | xargs -0 -n1 php -l",
+    "lint": "tools/lint.sh",
     "copyright": "tools/check_copyright.sh",
-    "docs": "bash -c '[ -f phpDocumentor.phar ] || curl -L -o phpDocumentor.phar https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.8.1/phpDocumentor.phar; php phpDocumentor.phar run -d src -t docs'",
+    "docs": "tools/docs.sh",
     "check": [
+      "echo '\\n==== Test ===='",
       "@test",
+      "echo '\\n==== Code Style (phpcs) ===='",
       "@cs",
+      "echo '\\n==== Mess Detector (phpmd) ===='",
       "@md",
+      "echo '\\n==== Static Analysis (phpstan) ===='",
       "@stan",
+      "echo '\\n==== Copyright ===='",
       "@copyright",
+      "echo '\\n==== Lint ===='",
       "@lint"
     ]
   },

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
     "cs": "phpcs",
     "md": "phpmd --ignore-violations-on-exit src/constants,src/laravel,src/parser,examples/EchoBot/src,examples/EchoBot/public,examples/KitchenSink/src,examples/KitchenSink/public text phpmd.xml",
     "stan": "phpstan analyse",
+    "lint": "find src/clients examples -name '*.php' -print0 | xargs -0 -n1 php -l",
     "copyright": "tools/check_copyright.sh",
     "docs": "bash -c '[ -f phpDocumentor.phar ] || curl -L -o phpDocumentor.phar https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.8.1/phpDocumentor.phar; php phpDocumentor.phar run -d src -t docs'",
     "check": [
@@ -58,7 +59,8 @@
       "@cs",
       "@md",
       "@stan",
-      "@copyright"
+      "@copyright",
+      "@lint"
     ]
   },
   "extra": {

--- a/tools/docs.sh
+++ b/tools/docs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+PHPDOC_VERSION="v3.8.1"
+PHPDOC_URL="https://github.com/phpDocumentor/phpDocumentor/releases/download/${PHPDOC_VERSION}/phpDocumentor.phar"
+PHPDOC_SHA256="aa00973d88b278fe59fd8dce826d8d5419df589cb7563ac379856ec305d6b938"
+
+if [ ! -f phpDocumentor.phar ]; then
+  curl -L -o phpDocumentor.phar "$PHPDOC_URL"
+  echo "$PHPDOC_SHA256  phpDocumentor.phar" | shasum -a 256 -c || {
+    rm -f phpDocumentor.phar
+    exit 1
+  }
+fi
+
+php phpDocumentor.phar run -d src -t docs

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+ERRORS=0
+COUNT=0
+
+while IFS= read -r -d '' file; do
+  COUNT=$((COUNT + 1))
+  output=$(php -l "$file" 2>&1)
+  if [ $? -ne 0 ]; then
+    echo "$output"
+    ERRORS=$((ERRORS + 1))
+  fi
+done < <(find src/clients examples -name '*.php' -print0)
+
+if [ $ERRORS -eq 0 ]; then
+  echo "Lint: no syntax errors ($COUNT files checked)"
+else
+  echo "[ERROR] $ERRORS file(s) with syntax errors"
+fi
+
+exit $ERRORS

--- a/tools/phpmd.sh
+++ b/tools/phpmd.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+DIRS=(
+  src/constants
+  src/laravel
+  src/parser
+  examples/EchoBot/src
+  examples/EchoBot/public
+  examples/KitchenSink/src
+  examples/KitchenSink/public
+)
+
+phpmd --ignore-violations-on-exit "$(IFS=,; echo "${DIRS[*]}")" text phpmd.xml


### PR DESCRIPTION
- cache is not necessary
- `composer check`  is better than specifying each command in github actions workfloow