### PR TITLE
Send line-bot-sdk-php's version as user agent

### DIFF
--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -37,9 +37,7 @@ jobs:
       - name: Generate codes
         run: python generate-code.py
       - name: Update document
-        run: |
-          wget https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.8.1/phpDocumentor.phar
-          php phpDocumentor.phar run -d src -t docs
+        run: composer docs
       - run: |
           diff_files=$(git --no-pager diff --name-only)
           diff_excluding_submodule=$(echo "$diff_files" | grep -v '^line-openapi$' || true)

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
   },
   "require": {
     "php": "^8.2",
+    "composer-runtime-api": "^2.0",
     "guzzlehttp/guzzle": "^7.3",
     "guzzlehttp/psr7": "^1.7 || ^2.0"
   },

--- a/docs/classes/LINE-Clients-ChannelAccessToken-Configuration.html
+++ b/docs/classes/LINE-Clients-ChannelAccessToken-Configuration.html
@@ -323,7 +323,7 @@ PHP version 8.1</p>
     <span>
                         &nbsp;: string            </span>
 </dt>
-<dd>User agent of the HTTP request, set to &quot;OpenAPI-Generator/{version}/PHP&quot; by default</dd>
+<dd>User agent of the HTTP request</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
     <a class="" href="classes/LINE-Clients-ChannelAccessToken-Configuration.html#property_username">$username</a>
@@ -1116,14 +1116,14 @@ PHP version 8.1</p>
 
     </aside>
 
-        <p class="phpdocumentor-summary">User agent of the HTTP request, set to &quot;OpenAPI-Generator/{version}/PHP&quot; by default</p>
+        <p class="phpdocumentor-summary">User agent of the HTTP request</p>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
         <span class="phpdocumentor-signature__visibility">protected</span>
             <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">$userAgent</span>
-     = <span class="phpdocumentor-signature__default-value">&#039;LINE-BotSDK-PHP/11&#039;</span></code>
+     = <span class="phpdocumentor-signature__default-value">&#039;LINE-BotSDK-PHP&#039;</span></code>
 
     
     
@@ -1268,7 +1268,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">233</span>
+    <span class="phpdocumentor-element-found-in__line">234</span>
 
     </aside>
 
@@ -1311,7 +1311,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">184</span>
+    <span class="phpdocumentor-element-found-in__line">185</span>
 
     </aside>
 
@@ -1366,7 +1366,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">210</span>
+    <span class="phpdocumentor-element-found-in__line">211</span>
 
     </aside>
 
@@ -1417,7 +1417,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">520</span>
+    <span class="phpdocumentor-element-found-in__line">521</span>
 
     </aside>
 
@@ -1472,7 +1472,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">257</span>
+    <span class="phpdocumentor-element-found-in__line">258</span>
 
     </aside>
 
@@ -1515,7 +1515,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">444</span>
+    <span class="phpdocumentor-element-found-in__line">445</span>
 
     </aside>
 
@@ -1558,7 +1558,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">377</span>
+    <span class="phpdocumentor-element-found-in__line">378</span>
 
     </aside>
 
@@ -1597,7 +1597,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">400</span>
+    <span class="phpdocumentor-element-found-in__line">401</span>
 
     </aside>
 
@@ -1636,7 +1636,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">476</span>
+    <span class="phpdocumentor-element-found-in__line">477</span>
 
     </aside>
 
@@ -1675,7 +1675,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">326</span>
+    <span class="phpdocumentor-element-found-in__line">327</span>
 
     </aside>
 
@@ -1718,7 +1718,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">599</span>
+    <span class="phpdocumentor-element-found-in__line">600</span>
 
     </aside>
 
@@ -1782,7 +1782,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">543</span>
+    <span class="phpdocumentor-element-found-in__line">544</span>
 
     </aside>
 
@@ -1825,7 +1825,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">561</span>
+    <span class="phpdocumentor-element-found-in__line">562</span>
 
     </aside>
 
@@ -1898,7 +1898,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">465</span>
+    <span class="phpdocumentor-element-found-in__line">466</span>
 
     </aside>
 
@@ -1941,7 +1941,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">303</span>
+    <span class="phpdocumentor-element-found-in__line">304</span>
 
     </aside>
 
@@ -1984,7 +1984,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">423</span>
+    <span class="phpdocumentor-element-found-in__line">424</span>
 
     </aside>
 
@@ -2027,7 +2027,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">354</span>
+    <span class="phpdocumentor-element-found-in__line">355</span>
 
     </aside>
 
@@ -2070,7 +2070,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">280</span>
+    <span class="phpdocumentor-element-found-in__line">281</span>
 
     </aside>
 
@@ -2113,7 +2113,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">222</span>
+    <span class="phpdocumentor-element-found-in__line">223</span>
 
     </aside>
 
@@ -2164,7 +2164,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">171</span>
+    <span class="phpdocumentor-element-found-in__line">172</span>
 
     </aside>
 
@@ -2224,7 +2224,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">197</span>
+    <span class="phpdocumentor-element-found-in__line">198</span>
 
     </aside>
 
@@ -2284,7 +2284,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">245</span>
+    <span class="phpdocumentor-element-found-in__line">246</span>
 
     </aside>
 
@@ -2335,7 +2335,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">433</span>
+    <span class="phpdocumentor-element-found-in__line">434</span>
 
     </aside>
 
@@ -2384,7 +2384,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">366</span>
+    <span class="phpdocumentor-element-found-in__line">367</span>
 
     </aside>
 
@@ -2435,7 +2435,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">389</span>
+    <span class="phpdocumentor-element-found-in__line">390</span>
 
     </aside>
 
@@ -2486,7 +2486,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">492</span>
+    <span class="phpdocumentor-element-found-in__line">493</span>
 
     </aside>
 
@@ -2533,7 +2533,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">315</span>
+    <span class="phpdocumentor-element-found-in__line">316</span>
 
     </aside>
 
@@ -2584,7 +2584,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">454</span>
+    <span class="phpdocumentor-element-found-in__line">455</span>
 
     </aside>
 
@@ -2633,7 +2633,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">292</span>
+    <span class="phpdocumentor-element-found-in__line">293</span>
 
     </aside>
 
@@ -2684,7 +2684,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">412</span>
+    <span class="phpdocumentor-element-found-in__line">413</span>
 
     </aside>
 
@@ -2735,7 +2735,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">339</span>
+    <span class="phpdocumentor-element-found-in__line">340</span>
 
     </aside>
 
@@ -2801,7 +2801,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">269</span>
+    <span class="phpdocumentor-element-found-in__line">270</span>
 
     </aside>
 
@@ -2852,7 +2852,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/channel-access-token/lib/Configuration.php"><a href="files/src-clients-channel-access-token-lib-configuration.html"><abbr title="src/clients/channel-access-token/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">502</span>
+    <span class="phpdocumentor-element-found-in__line">503</span>
 
     </aside>
 

--- a/docs/classes/LINE-Clients-Insight-Configuration.html
+++ b/docs/classes/LINE-Clients-Insight-Configuration.html
@@ -323,7 +323,7 @@ PHP version 8.1</p>
     <span>
                         &nbsp;: string            </span>
 </dt>
-<dd>User agent of the HTTP request, set to &quot;OpenAPI-Generator/{version}/PHP&quot; by default</dd>
+<dd>User agent of the HTTP request</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
     <a class="" href="classes/LINE-Clients-Insight-Configuration.html#property_username">$username</a>
@@ -1116,14 +1116,14 @@ PHP version 8.1</p>
 
     </aside>
 
-        <p class="phpdocumentor-summary">User agent of the HTTP request, set to &quot;OpenAPI-Generator/{version}/PHP&quot; by default</p>
+        <p class="phpdocumentor-summary">User agent of the HTTP request</p>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
         <span class="phpdocumentor-signature__visibility">protected</span>
             <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">$userAgent</span>
-     = <span class="phpdocumentor-signature__default-value">&#039;LINE-BotSDK-PHP/11&#039;</span></code>
+     = <span class="phpdocumentor-signature__default-value">&#039;LINE-BotSDK-PHP&#039;</span></code>
 
     
     
@@ -1268,7 +1268,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">233</span>
+    <span class="phpdocumentor-element-found-in__line">234</span>
 
     </aside>
 
@@ -1311,7 +1311,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">184</span>
+    <span class="phpdocumentor-element-found-in__line">185</span>
 
     </aside>
 
@@ -1366,7 +1366,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">210</span>
+    <span class="phpdocumentor-element-found-in__line">211</span>
 
     </aside>
 
@@ -1417,7 +1417,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">520</span>
+    <span class="phpdocumentor-element-found-in__line">521</span>
 
     </aside>
 
@@ -1472,7 +1472,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">257</span>
+    <span class="phpdocumentor-element-found-in__line">258</span>
 
     </aside>
 
@@ -1515,7 +1515,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">444</span>
+    <span class="phpdocumentor-element-found-in__line">445</span>
 
     </aside>
 
@@ -1558,7 +1558,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">377</span>
+    <span class="phpdocumentor-element-found-in__line">378</span>
 
     </aside>
 
@@ -1597,7 +1597,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">400</span>
+    <span class="phpdocumentor-element-found-in__line">401</span>
 
     </aside>
 
@@ -1636,7 +1636,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">476</span>
+    <span class="phpdocumentor-element-found-in__line">477</span>
 
     </aside>
 
@@ -1675,7 +1675,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">326</span>
+    <span class="phpdocumentor-element-found-in__line">327</span>
 
     </aside>
 
@@ -1718,7 +1718,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">599</span>
+    <span class="phpdocumentor-element-found-in__line">600</span>
 
     </aside>
 
@@ -1782,7 +1782,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">543</span>
+    <span class="phpdocumentor-element-found-in__line">544</span>
 
     </aside>
 
@@ -1825,7 +1825,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">561</span>
+    <span class="phpdocumentor-element-found-in__line">562</span>
 
     </aside>
 
@@ -1898,7 +1898,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">465</span>
+    <span class="phpdocumentor-element-found-in__line">466</span>
 
     </aside>
 
@@ -1941,7 +1941,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">303</span>
+    <span class="phpdocumentor-element-found-in__line">304</span>
 
     </aside>
 
@@ -1984,7 +1984,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">423</span>
+    <span class="phpdocumentor-element-found-in__line">424</span>
 
     </aside>
 
@@ -2027,7 +2027,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">354</span>
+    <span class="phpdocumentor-element-found-in__line">355</span>
 
     </aside>
 
@@ -2070,7 +2070,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">280</span>
+    <span class="phpdocumentor-element-found-in__line">281</span>
 
     </aside>
 
@@ -2113,7 +2113,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">222</span>
+    <span class="phpdocumentor-element-found-in__line">223</span>
 
     </aside>
 
@@ -2164,7 +2164,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">171</span>
+    <span class="phpdocumentor-element-found-in__line">172</span>
 
     </aside>
 
@@ -2224,7 +2224,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">197</span>
+    <span class="phpdocumentor-element-found-in__line">198</span>
 
     </aside>
 
@@ -2284,7 +2284,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">245</span>
+    <span class="phpdocumentor-element-found-in__line">246</span>
 
     </aside>
 
@@ -2335,7 +2335,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">433</span>
+    <span class="phpdocumentor-element-found-in__line">434</span>
 
     </aside>
 
@@ -2384,7 +2384,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">366</span>
+    <span class="phpdocumentor-element-found-in__line">367</span>
 
     </aside>
 
@@ -2435,7 +2435,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">389</span>
+    <span class="phpdocumentor-element-found-in__line">390</span>
 
     </aside>
 
@@ -2486,7 +2486,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">492</span>
+    <span class="phpdocumentor-element-found-in__line">493</span>
 
     </aside>
 
@@ -2533,7 +2533,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">315</span>
+    <span class="phpdocumentor-element-found-in__line">316</span>
 
     </aside>
 
@@ -2584,7 +2584,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">454</span>
+    <span class="phpdocumentor-element-found-in__line">455</span>
 
     </aside>
 
@@ -2633,7 +2633,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">292</span>
+    <span class="phpdocumentor-element-found-in__line">293</span>
 
     </aside>
 
@@ -2684,7 +2684,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">412</span>
+    <span class="phpdocumentor-element-found-in__line">413</span>
 
     </aside>
 
@@ -2735,7 +2735,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">339</span>
+    <span class="phpdocumentor-element-found-in__line">340</span>
 
     </aside>
 
@@ -2801,7 +2801,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">269</span>
+    <span class="phpdocumentor-element-found-in__line">270</span>
 
     </aside>
 
@@ -2852,7 +2852,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/insight/lib/Configuration.php"><a href="files/src-clients-insight-lib-configuration.html"><abbr title="src/clients/insight/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">502</span>
+    <span class="phpdocumentor-element-found-in__line">503</span>
 
     </aside>
 

--- a/docs/classes/LINE-Clients-Liff-Configuration.html
+++ b/docs/classes/LINE-Clients-Liff-Configuration.html
@@ -323,7 +323,7 @@ PHP version 8.1</p>
     <span>
                         &nbsp;: string            </span>
 </dt>
-<dd>User agent of the HTTP request, set to &quot;OpenAPI-Generator/{version}/PHP&quot; by default</dd>
+<dd>User agent of the HTTP request</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
     <a class="" href="classes/LINE-Clients-Liff-Configuration.html#property_username">$username</a>
@@ -1116,14 +1116,14 @@ PHP version 8.1</p>
 
     </aside>
 
-        <p class="phpdocumentor-summary">User agent of the HTTP request, set to &quot;OpenAPI-Generator/{version}/PHP&quot; by default</p>
+        <p class="phpdocumentor-summary">User agent of the HTTP request</p>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
         <span class="phpdocumentor-signature__visibility">protected</span>
             <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">$userAgent</span>
-     = <span class="phpdocumentor-signature__default-value">&#039;LINE-BotSDK-PHP/11&#039;</span></code>
+     = <span class="phpdocumentor-signature__default-value">&#039;LINE-BotSDK-PHP&#039;</span></code>
 
     
     
@@ -1268,7 +1268,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">233</span>
+    <span class="phpdocumentor-element-found-in__line">234</span>
 
     </aside>
 
@@ -1311,7 +1311,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">184</span>
+    <span class="phpdocumentor-element-found-in__line">185</span>
 
     </aside>
 
@@ -1366,7 +1366,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">210</span>
+    <span class="phpdocumentor-element-found-in__line">211</span>
 
     </aside>
 
@@ -1417,7 +1417,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">520</span>
+    <span class="phpdocumentor-element-found-in__line">521</span>
 
     </aside>
 
@@ -1472,7 +1472,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">257</span>
+    <span class="phpdocumentor-element-found-in__line">258</span>
 
     </aside>
 
@@ -1515,7 +1515,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">444</span>
+    <span class="phpdocumentor-element-found-in__line">445</span>
 
     </aside>
 
@@ -1558,7 +1558,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">377</span>
+    <span class="phpdocumentor-element-found-in__line">378</span>
 
     </aside>
 
@@ -1597,7 +1597,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">400</span>
+    <span class="phpdocumentor-element-found-in__line">401</span>
 
     </aside>
 
@@ -1636,7 +1636,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">476</span>
+    <span class="phpdocumentor-element-found-in__line">477</span>
 
     </aside>
 
@@ -1675,7 +1675,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">326</span>
+    <span class="phpdocumentor-element-found-in__line">327</span>
 
     </aside>
 
@@ -1718,7 +1718,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">599</span>
+    <span class="phpdocumentor-element-found-in__line">600</span>
 
     </aside>
 
@@ -1782,7 +1782,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">543</span>
+    <span class="phpdocumentor-element-found-in__line">544</span>
 
     </aside>
 
@@ -1825,7 +1825,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">561</span>
+    <span class="phpdocumentor-element-found-in__line">562</span>
 
     </aside>
 
@@ -1898,7 +1898,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">465</span>
+    <span class="phpdocumentor-element-found-in__line">466</span>
 
     </aside>
 
@@ -1941,7 +1941,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">303</span>
+    <span class="phpdocumentor-element-found-in__line">304</span>
 
     </aside>
 
@@ -1984,7 +1984,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">423</span>
+    <span class="phpdocumentor-element-found-in__line">424</span>
 
     </aside>
 
@@ -2027,7 +2027,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">354</span>
+    <span class="phpdocumentor-element-found-in__line">355</span>
 
     </aside>
 
@@ -2070,7 +2070,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">280</span>
+    <span class="phpdocumentor-element-found-in__line">281</span>
 
     </aside>
 
@@ -2113,7 +2113,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">222</span>
+    <span class="phpdocumentor-element-found-in__line">223</span>
 
     </aside>
 
@@ -2164,7 +2164,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">171</span>
+    <span class="phpdocumentor-element-found-in__line">172</span>
 
     </aside>
 
@@ -2224,7 +2224,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">197</span>
+    <span class="phpdocumentor-element-found-in__line">198</span>
 
     </aside>
 
@@ -2284,7 +2284,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">245</span>
+    <span class="phpdocumentor-element-found-in__line">246</span>
 
     </aside>
 
@@ -2335,7 +2335,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">433</span>
+    <span class="phpdocumentor-element-found-in__line">434</span>
 
     </aside>
 
@@ -2384,7 +2384,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">366</span>
+    <span class="phpdocumentor-element-found-in__line">367</span>
 
     </aside>
 
@@ -2435,7 +2435,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">389</span>
+    <span class="phpdocumentor-element-found-in__line">390</span>
 
     </aside>
 
@@ -2486,7 +2486,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">492</span>
+    <span class="phpdocumentor-element-found-in__line">493</span>
 
     </aside>
 
@@ -2533,7 +2533,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">315</span>
+    <span class="phpdocumentor-element-found-in__line">316</span>
 
     </aside>
 
@@ -2584,7 +2584,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">454</span>
+    <span class="phpdocumentor-element-found-in__line">455</span>
 
     </aside>
 
@@ -2633,7 +2633,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">292</span>
+    <span class="phpdocumentor-element-found-in__line">293</span>
 
     </aside>
 
@@ -2684,7 +2684,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">412</span>
+    <span class="phpdocumentor-element-found-in__line">413</span>
 
     </aside>
 
@@ -2735,7 +2735,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">339</span>
+    <span class="phpdocumentor-element-found-in__line">340</span>
 
     </aside>
 
@@ -2801,7 +2801,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">269</span>
+    <span class="phpdocumentor-element-found-in__line">270</span>
 
     </aside>
 
@@ -2852,7 +2852,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/liff/lib/Configuration.php"><a href="files/src-clients-liff-lib-configuration.html"><abbr title="src/clients/liff/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">502</span>
+    <span class="phpdocumentor-element-found-in__line">503</span>
 
     </aside>
 

--- a/docs/classes/LINE-Clients-ManageAudience-Configuration.html
+++ b/docs/classes/LINE-Clients-ManageAudience-Configuration.html
@@ -323,7 +323,7 @@ PHP version 8.1</p>
     <span>
                         &nbsp;: string            </span>
 </dt>
-<dd>User agent of the HTTP request, set to &quot;OpenAPI-Generator/{version}/PHP&quot; by default</dd>
+<dd>User agent of the HTTP request</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
     <a class="" href="classes/LINE-Clients-ManageAudience-Configuration.html#property_username">$username</a>
@@ -1116,14 +1116,14 @@ PHP version 8.1</p>
 
     </aside>
 
-        <p class="phpdocumentor-summary">User agent of the HTTP request, set to &quot;OpenAPI-Generator/{version}/PHP&quot; by default</p>
+        <p class="phpdocumentor-summary">User agent of the HTTP request</p>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
         <span class="phpdocumentor-signature__visibility">protected</span>
             <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">$userAgent</span>
-     = <span class="phpdocumentor-signature__default-value">&#039;LINE-BotSDK-PHP/11&#039;</span></code>
+     = <span class="phpdocumentor-signature__default-value">&#039;LINE-BotSDK-PHP&#039;</span></code>
 
     
     
@@ -1268,7 +1268,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">233</span>
+    <span class="phpdocumentor-element-found-in__line">234</span>
 
     </aside>
 
@@ -1311,7 +1311,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">184</span>
+    <span class="phpdocumentor-element-found-in__line">185</span>
 
     </aside>
 
@@ -1366,7 +1366,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">210</span>
+    <span class="phpdocumentor-element-found-in__line">211</span>
 
     </aside>
 
@@ -1417,7 +1417,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">520</span>
+    <span class="phpdocumentor-element-found-in__line">521</span>
 
     </aside>
 
@@ -1472,7 +1472,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">257</span>
+    <span class="phpdocumentor-element-found-in__line">258</span>
 
     </aside>
 
@@ -1515,7 +1515,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">444</span>
+    <span class="phpdocumentor-element-found-in__line">445</span>
 
     </aside>
 
@@ -1558,7 +1558,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">377</span>
+    <span class="phpdocumentor-element-found-in__line">378</span>
 
     </aside>
 
@@ -1597,7 +1597,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">400</span>
+    <span class="phpdocumentor-element-found-in__line">401</span>
 
     </aside>
 
@@ -1636,7 +1636,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">476</span>
+    <span class="phpdocumentor-element-found-in__line">477</span>
 
     </aside>
 
@@ -1675,7 +1675,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">326</span>
+    <span class="phpdocumentor-element-found-in__line">327</span>
 
     </aside>
 
@@ -1718,7 +1718,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">599</span>
+    <span class="phpdocumentor-element-found-in__line">600</span>
 
     </aside>
 
@@ -1782,7 +1782,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">543</span>
+    <span class="phpdocumentor-element-found-in__line">544</span>
 
     </aside>
 
@@ -1825,7 +1825,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">561</span>
+    <span class="phpdocumentor-element-found-in__line">562</span>
 
     </aside>
 
@@ -1898,7 +1898,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">465</span>
+    <span class="phpdocumentor-element-found-in__line">466</span>
 
     </aside>
 
@@ -1941,7 +1941,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">303</span>
+    <span class="phpdocumentor-element-found-in__line">304</span>
 
     </aside>
 
@@ -1984,7 +1984,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">423</span>
+    <span class="phpdocumentor-element-found-in__line">424</span>
 
     </aside>
 
@@ -2027,7 +2027,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">354</span>
+    <span class="phpdocumentor-element-found-in__line">355</span>
 
     </aside>
 
@@ -2070,7 +2070,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">280</span>
+    <span class="phpdocumentor-element-found-in__line">281</span>
 
     </aside>
 
@@ -2113,7 +2113,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">222</span>
+    <span class="phpdocumentor-element-found-in__line">223</span>
 
     </aside>
 
@@ -2164,7 +2164,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">171</span>
+    <span class="phpdocumentor-element-found-in__line">172</span>
 
     </aside>
 
@@ -2224,7 +2224,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">197</span>
+    <span class="phpdocumentor-element-found-in__line">198</span>
 
     </aside>
 
@@ -2284,7 +2284,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">245</span>
+    <span class="phpdocumentor-element-found-in__line">246</span>
 
     </aside>
 
@@ -2335,7 +2335,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">433</span>
+    <span class="phpdocumentor-element-found-in__line">434</span>
 
     </aside>
 
@@ -2384,7 +2384,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">366</span>
+    <span class="phpdocumentor-element-found-in__line">367</span>
 
     </aside>
 
@@ -2435,7 +2435,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">389</span>
+    <span class="phpdocumentor-element-found-in__line">390</span>
 
     </aside>
 
@@ -2486,7 +2486,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">492</span>
+    <span class="phpdocumentor-element-found-in__line">493</span>
 
     </aside>
 
@@ -2533,7 +2533,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">315</span>
+    <span class="phpdocumentor-element-found-in__line">316</span>
 
     </aside>
 
@@ -2584,7 +2584,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">454</span>
+    <span class="phpdocumentor-element-found-in__line">455</span>
 
     </aside>
 
@@ -2633,7 +2633,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">292</span>
+    <span class="phpdocumentor-element-found-in__line">293</span>
 
     </aside>
 
@@ -2684,7 +2684,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">412</span>
+    <span class="phpdocumentor-element-found-in__line">413</span>
 
     </aside>
 
@@ -2735,7 +2735,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">339</span>
+    <span class="phpdocumentor-element-found-in__line">340</span>
 
     </aside>
 
@@ -2801,7 +2801,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">269</span>
+    <span class="phpdocumentor-element-found-in__line">270</span>
 
     </aside>
 
@@ -2852,7 +2852,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/manage-audience/lib/Configuration.php"><a href="files/src-clients-manage-audience-lib-configuration.html"><abbr title="src/clients/manage-audience/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">502</span>
+    <span class="phpdocumentor-element-found-in__line">503</span>
 
     </aside>
 

--- a/docs/classes/LINE-Clients-MessagingApi-Configuration.html
+++ b/docs/classes/LINE-Clients-MessagingApi-Configuration.html
@@ -323,7 +323,7 @@ PHP version 8.1</p>
     <span>
                         &nbsp;: string            </span>
 </dt>
-<dd>User agent of the HTTP request, set to &quot;OpenAPI-Generator/{version}/PHP&quot; by default</dd>
+<dd>User agent of the HTTP request</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
     <a class="" href="classes/LINE-Clients-MessagingApi-Configuration.html#property_username">$username</a>
@@ -1116,14 +1116,14 @@ PHP version 8.1</p>
 
     </aside>
 
-        <p class="phpdocumentor-summary">User agent of the HTTP request, set to &quot;OpenAPI-Generator/{version}/PHP&quot; by default</p>
+        <p class="phpdocumentor-summary">User agent of the HTTP request</p>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
         <span class="phpdocumentor-signature__visibility">protected</span>
             <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">$userAgent</span>
-     = <span class="phpdocumentor-signature__default-value">&#039;LINE-BotSDK-PHP/11&#039;</span></code>
+     = <span class="phpdocumentor-signature__default-value">&#039;LINE-BotSDK-PHP&#039;</span></code>
 
     
     
@@ -1268,7 +1268,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">233</span>
+    <span class="phpdocumentor-element-found-in__line">234</span>
 
     </aside>
 
@@ -1311,7 +1311,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">184</span>
+    <span class="phpdocumentor-element-found-in__line">185</span>
 
     </aside>
 
@@ -1366,7 +1366,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">210</span>
+    <span class="phpdocumentor-element-found-in__line">211</span>
 
     </aside>
 
@@ -1417,7 +1417,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">520</span>
+    <span class="phpdocumentor-element-found-in__line">521</span>
 
     </aside>
 
@@ -1472,7 +1472,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">257</span>
+    <span class="phpdocumentor-element-found-in__line">258</span>
 
     </aside>
 
@@ -1515,7 +1515,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">444</span>
+    <span class="phpdocumentor-element-found-in__line">445</span>
 
     </aside>
 
@@ -1558,7 +1558,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">377</span>
+    <span class="phpdocumentor-element-found-in__line">378</span>
 
     </aside>
 
@@ -1597,7 +1597,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">400</span>
+    <span class="phpdocumentor-element-found-in__line">401</span>
 
     </aside>
 
@@ -1636,7 +1636,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">476</span>
+    <span class="phpdocumentor-element-found-in__line">477</span>
 
     </aside>
 
@@ -1675,7 +1675,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">326</span>
+    <span class="phpdocumentor-element-found-in__line">327</span>
 
     </aside>
 
@@ -1718,7 +1718,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">599</span>
+    <span class="phpdocumentor-element-found-in__line">600</span>
 
     </aside>
 
@@ -1782,7 +1782,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">543</span>
+    <span class="phpdocumentor-element-found-in__line">544</span>
 
     </aside>
 
@@ -1825,7 +1825,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">561</span>
+    <span class="phpdocumentor-element-found-in__line">562</span>
 
     </aside>
 
@@ -1898,7 +1898,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">465</span>
+    <span class="phpdocumentor-element-found-in__line">466</span>
 
     </aside>
 
@@ -1941,7 +1941,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">303</span>
+    <span class="phpdocumentor-element-found-in__line">304</span>
 
     </aside>
 
@@ -1984,7 +1984,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">423</span>
+    <span class="phpdocumentor-element-found-in__line">424</span>
 
     </aside>
 
@@ -2027,7 +2027,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">354</span>
+    <span class="phpdocumentor-element-found-in__line">355</span>
 
     </aside>
 
@@ -2070,7 +2070,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">280</span>
+    <span class="phpdocumentor-element-found-in__line">281</span>
 
     </aside>
 
@@ -2113,7 +2113,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">222</span>
+    <span class="phpdocumentor-element-found-in__line">223</span>
 
     </aside>
 
@@ -2164,7 +2164,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">171</span>
+    <span class="phpdocumentor-element-found-in__line">172</span>
 
     </aside>
 
@@ -2224,7 +2224,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">197</span>
+    <span class="phpdocumentor-element-found-in__line">198</span>
 
     </aside>
 
@@ -2284,7 +2284,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">245</span>
+    <span class="phpdocumentor-element-found-in__line">246</span>
 
     </aside>
 
@@ -2335,7 +2335,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">433</span>
+    <span class="phpdocumentor-element-found-in__line">434</span>
 
     </aside>
 
@@ -2384,7 +2384,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">366</span>
+    <span class="phpdocumentor-element-found-in__line">367</span>
 
     </aside>
 
@@ -2435,7 +2435,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">389</span>
+    <span class="phpdocumentor-element-found-in__line">390</span>
 
     </aside>
 
@@ -2486,7 +2486,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">492</span>
+    <span class="phpdocumentor-element-found-in__line">493</span>
 
     </aside>
 
@@ -2533,7 +2533,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">315</span>
+    <span class="phpdocumentor-element-found-in__line">316</span>
 
     </aside>
 
@@ -2584,7 +2584,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">454</span>
+    <span class="phpdocumentor-element-found-in__line">455</span>
 
     </aside>
 
@@ -2633,7 +2633,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">292</span>
+    <span class="phpdocumentor-element-found-in__line">293</span>
 
     </aside>
 
@@ -2684,7 +2684,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">412</span>
+    <span class="phpdocumentor-element-found-in__line">413</span>
 
     </aside>
 
@@ -2735,7 +2735,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">339</span>
+    <span class="phpdocumentor-element-found-in__line">340</span>
 
     </aside>
 
@@ -2801,7 +2801,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">269</span>
+    <span class="phpdocumentor-element-found-in__line">270</span>
 
     </aside>
 
@@ -2852,7 +2852,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/clients/messaging-api/lib/Configuration.php"><a href="files/src-clients-messaging-api-lib-configuration.html"><abbr title="src/clients/messaging-api/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">502</span>
+    <span class="phpdocumentor-element-found-in__line">503</span>
 
     </aside>
 

--- a/docs/classes/LINE-Webhook-Configuration.html
+++ b/docs/classes/LINE-Webhook-Configuration.html
@@ -321,7 +321,7 @@ PHP version 8.1</p>
     <span>
                         &nbsp;: string            </span>
 </dt>
-<dd>User agent of the HTTP request, set to &quot;OpenAPI-Generator/{version}/PHP&quot; by default</dd>
+<dd>User agent of the HTTP request</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
     <a class="" href="classes/LINE-Webhook-Configuration.html#property_username">$username</a>
@@ -1114,14 +1114,14 @@ PHP version 8.1</p>
 
     </aside>
 
-        <p class="phpdocumentor-summary">User agent of the HTTP request, set to &quot;OpenAPI-Generator/{version}/PHP&quot; by default</p>
+        <p class="phpdocumentor-summary">User agent of the HTTP request</p>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
         <span class="phpdocumentor-signature__visibility">protected</span>
             <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">$userAgent</span>
-     = <span class="phpdocumentor-signature__default-value">&#039;OpenAPI-Generator/1.0.0/PHP&#039;</span></code>
+     = <span class="phpdocumentor-signature__default-value">&#039;LINE-BotSDK-PHP&#039;</span></code>
 
     
     
@@ -1266,7 +1266,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">233</span>
+    <span class="phpdocumentor-element-found-in__line">234</span>
 
     </aside>
 
@@ -1309,7 +1309,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">184</span>
+    <span class="phpdocumentor-element-found-in__line">185</span>
 
     </aside>
 
@@ -1364,7 +1364,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">210</span>
+    <span class="phpdocumentor-element-found-in__line">211</span>
 
     </aside>
 
@@ -1415,7 +1415,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">520</span>
+    <span class="phpdocumentor-element-found-in__line">521</span>
 
     </aside>
 
@@ -1470,7 +1470,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">257</span>
+    <span class="phpdocumentor-element-found-in__line">258</span>
 
     </aside>
 
@@ -1513,7 +1513,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">444</span>
+    <span class="phpdocumentor-element-found-in__line">445</span>
 
     </aside>
 
@@ -1556,7 +1556,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">377</span>
+    <span class="phpdocumentor-element-found-in__line">378</span>
 
     </aside>
 
@@ -1595,7 +1595,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">400</span>
+    <span class="phpdocumentor-element-found-in__line">401</span>
 
     </aside>
 
@@ -1634,7 +1634,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">476</span>
+    <span class="phpdocumentor-element-found-in__line">477</span>
 
     </aside>
 
@@ -1673,7 +1673,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">326</span>
+    <span class="phpdocumentor-element-found-in__line">327</span>
 
     </aside>
 
@@ -1716,7 +1716,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">599</span>
+    <span class="phpdocumentor-element-found-in__line">600</span>
 
     </aside>
 
@@ -1780,7 +1780,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">543</span>
+    <span class="phpdocumentor-element-found-in__line">544</span>
 
     </aside>
 
@@ -1823,7 +1823,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">561</span>
+    <span class="phpdocumentor-element-found-in__line">562</span>
 
     </aside>
 
@@ -1896,7 +1896,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">465</span>
+    <span class="phpdocumentor-element-found-in__line">466</span>
 
     </aside>
 
@@ -1939,7 +1939,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">303</span>
+    <span class="phpdocumentor-element-found-in__line">304</span>
 
     </aside>
 
@@ -1982,7 +1982,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">423</span>
+    <span class="phpdocumentor-element-found-in__line">424</span>
 
     </aside>
 
@@ -2025,7 +2025,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">354</span>
+    <span class="phpdocumentor-element-found-in__line">355</span>
 
     </aside>
 
@@ -2068,7 +2068,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">280</span>
+    <span class="phpdocumentor-element-found-in__line">281</span>
 
     </aside>
 
@@ -2111,7 +2111,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">222</span>
+    <span class="phpdocumentor-element-found-in__line">223</span>
 
     </aside>
 
@@ -2162,7 +2162,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">171</span>
+    <span class="phpdocumentor-element-found-in__line">172</span>
 
     </aside>
 
@@ -2222,7 +2222,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">197</span>
+    <span class="phpdocumentor-element-found-in__line">198</span>
 
     </aside>
 
@@ -2282,7 +2282,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">245</span>
+    <span class="phpdocumentor-element-found-in__line">246</span>
 
     </aside>
 
@@ -2333,7 +2333,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">433</span>
+    <span class="phpdocumentor-element-found-in__line">434</span>
 
     </aside>
 
@@ -2382,7 +2382,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">366</span>
+    <span class="phpdocumentor-element-found-in__line">367</span>
 
     </aside>
 
@@ -2433,7 +2433,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">389</span>
+    <span class="phpdocumentor-element-found-in__line">390</span>
 
     </aside>
 
@@ -2484,7 +2484,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">492</span>
+    <span class="phpdocumentor-element-found-in__line">493</span>
 
     </aside>
 
@@ -2531,7 +2531,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">315</span>
+    <span class="phpdocumentor-element-found-in__line">316</span>
 
     </aside>
 
@@ -2582,7 +2582,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">454</span>
+    <span class="phpdocumentor-element-found-in__line">455</span>
 
     </aside>
 
@@ -2631,7 +2631,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">292</span>
+    <span class="phpdocumentor-element-found-in__line">293</span>
 
     </aside>
 
@@ -2682,7 +2682,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">412</span>
+    <span class="phpdocumentor-element-found-in__line">413</span>
 
     </aside>
 
@@ -2733,7 +2733,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">339</span>
+    <span class="phpdocumentor-element-found-in__line">340</span>
 
     </aside>
 
@@ -2799,7 +2799,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">269</span>
+    <span class="phpdocumentor-element-found-in__line">270</span>
 
     </aside>
 
@@ -2850,7 +2850,7 @@ PHP version 8.1</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/webhook/lib/Configuration.php"><a href="files/src-webhook-lib-configuration.html"><abbr title="src/webhook/lib/Configuration.php">Configuration.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">502</span>
+    <span class="phpdocumentor-element-found-in__line">503</span>
 
     </aside>
 

--- a/docs/files/src-constants-sdkuseragent.html
+++ b/docs/files/src-constants-sdkuseragent.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+            <title>LINE Messaging API SDK for PHP</title>
+    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@100;200;300;400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
+                <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
+        <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
+        <script src="js/template.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
+    </head>
+<body id="top">
+    <header class="phpdocumentor-header phpdocumentor-section">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">LINE Messaging API SDK for PHP</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
+    <section data-search-form class="phpdocumentor-search">
+    <label>
+        <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
+        <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
+    </label>
+</section>
+
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
+
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -three phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category -namespaces">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/line.html" class="">LINE</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/line-clients.html" class="">Clients</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/line-constants.html" class="">Constants</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/line-laravel.html" class="">Laravel</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/line-parser.html" class="">Parser</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/line-webhook.html" class="">Webhook</a>
+                
+            </li>
+            </ul>
+
+                        </section>
+                <section class="phpdocumentor-sidebar__category -packages">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/Application.html" class="">Application</a>
+</h4>
+
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/LINE.html" class="">LINE</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="packages/LINE-Clients.html" class="">Clients</a>
+                
+            </li>
+                    <li>
+                <a href="packages/LINE-LINEBot.html" class="">LINEBot</a>
+                
+            </li>
+                    <li>
+                <a href="packages/LINE-Webhook.html" class="">Webhook</a>
+                
+            </li>
+            </ul>
+
+                        </section>
+            
+    <section class="phpdocumentor-sidebar__category -reports">
+        <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
+    </section>
+
+    <section class="phpdocumentor-sidebar__category -indices">
+        <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
+    </section>
+</aside>
+
+            <div class="phpdocumentor-column -nine phpdocumentor-content">
+                                <section>
+                                        <ul class="phpdocumentor-breadcrumbs">
+    </ul>
+
+    <article class="phpdocumentor-element -file">
+        <h2 class="phpdocumentor-content__title">SdkUserAgent.php</h2>
+
+            <p class="phpdocumentor-summary">Copyright 2026 LINE Corporation</p>
+
+        
+            <section class="phpdocumentor-description"><p>LINE Corporation licenses this file to you under the Apache License,
+version 2.0 (the &quot;License&quot;); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:</p>
+<p>https://www.apache.org/licenses/LICENSE-2.0</p>
+<p>Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.</p>
+</section>
+
+        
+
+
+        
+<h3 id="toc">
+    Table of Contents
+    <a href="files/src-constants-sdkuseragent.html#toc" class="headerlink"><i class="fas fa-link"></i></a>
+
+</h3>
+
+
+
+
+
+
+
+
+
+
+
+
+
+        
+
+        
+        <div class="phpdocumentor-modal" id="source-view">
+    <div class="phpdocumentor-modal-bg" data-exit-button></div>
+    <div class="phpdocumentor-modal-container">
+        <div class="phpdocumentor-modal-content">
+            <pre style="max-height: 500px; overflow-y: scroll" data-src="files/src/constants/SdkUserAgent.php.txt" class="language-php line-numbers linkable-line-numbers"></pre>
+        </div>
+        <button data-exit-button class="phpdocumentor-modal__close">&times;</button>
+    </div>
+</div>
+
+    <script type="text/javascript">
+        (function () {
+            function loadExternalCodeSnippet(el, url, line) {
+                Array.prototype.slice.call(el.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                    const src = url || pre.getAttribute('data-src').replace(/\\/g, '/');
+                    const language = 'php';
+
+                    const code = document.createElement('code');
+                    code.className = 'language-' + language;
+                    pre.textContent = '';
+                    pre.setAttribute('data-line', line)
+                    code.textContent = 'Loading…';
+                    pre.appendChild(code);
+
+                    var xhr = new XMLHttpRequest();
+
+                    xhr.open('GET', src, true);
+
+                    xhr.onreadystatechange = function () {
+                        if (xhr.readyState !== 4) {
+                            return;
+                        }
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+                            Prism.highlightElement(code);
+                            d=document.getElementsByClassName("line-numbers");
+                            d[0].scrollTop = d[0].children[1].offsetTop;
+                            return;
+                        }
+
+                        if (xhr.status === 404) {
+                            code.textContent = '✖ Error: File could not be found';
+                            return;
+                        }
+
+                        if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                            return;
+                        }
+
+                        code.textContent = '✖ Error: An unknown error occurred';
+                    };
+
+                    xhr.send(null);
+                });
+            }
+
+            const modalButtons = document.querySelectorAll("[data-modal]");
+            const openedAsLocalFile = window.location.protocol === 'file:';
+            if (modalButtons.length > 0 && openedAsLocalFile) {
+                console.warn(
+                    'Viewing the source code is unavailable because you are opening this page from the file:// scheme; ' +
+                    'browsers block XHR requests when a page is opened this way'
+                );
+            }
+
+            modalButtons.forEach(function (trigger) {
+                if (openedAsLocalFile) {
+                    trigger.setAttribute("hidden", "hidden");
+                }
+
+                trigger.addEventListener("click", function (event) {
+                    event.preventDefault();
+                    const modal = document.getElementById(trigger.dataset.modal);
+                    if (!modal) {
+                        console.error(`Modal with id "${trigger.dataset.modal}" could not be found`);
+                        return;
+                    }
+                    modal.classList.add("phpdocumentor-modal__open");
+
+                    loadExternalCodeSnippet(modal, trigger.dataset.src || null, trigger.dataset.line)
+                    const exits = modal.querySelectorAll("[data-exit-button]");
+                    exits.forEach(function (exit) {
+                        exit.addEventListener("click", function (event) {
+                            event.preventDefault();
+                            modal.classList.remove("phpdocumentor-modal__open");
+                        });
+                    });
+                });
+            });
+        })();
+    </script>
+
+    </article>
+                                </section>
+                <section class="phpdocumentor-on-this-page__sidebar">
+                            
+    <section class="phpdocumentor-on-this-page__content">
+        <strong class="phpdocumentor-on-this-page__title">On this page</strong>
+
+        <ul class="phpdocumentor-list -clean">
+            <li class="phpdocumentor-on-this-page-section__title">Table Of Contents</li>
+            <li>
+                <ul class="phpdocumentor-list -clean">
+                                                                                                                                                                                </ul>
+            </li>
+
+            
+                    </ul>
+    </section>
+
+                </section>
+                            </div>
+            <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
+        </div>
+        <a href="files/src-constants-sdkuseragent.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+
+    </main>
+
+    <script>
+        cssVars({});
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
+</body>
+</html>

--- a/docs/indices/files.html
+++ b/docs/indices/files.html
@@ -599,6 +599,7 @@
                         </ul>
                                                         <h3>S</h3>
             <ul class="phpdocumentor-list">
+                            <li><a href="files/src-constants-sdkuseragent.html"><abbr title="src/constants/SdkUserAgent.php">SdkUserAgent.php</abbr></a></li>
                             <li><a href="files/src-clients-messaging-api-lib-model-sender.html"><abbr title="src/clients/messaging-api/lib/Model/Sender.php">Sender.php</abbr></a></li>
                             <li><a href="files/src-clients-messaging-api-lib-model-sentmessage.html"><abbr title="src/clients/messaging-api/lib/Model/SentMessage.php">SentMessage.php</abbr></a></li>
                             <li><a href="files/src-clients-messaging-api-lib-model-setwebhookendpointrequest.html"><abbr title="src/clients/messaging-api/lib/Model/SetWebhookEndpointRequest.php">SetWebhookEndpointRequest.php</abbr></a></li>

--- a/generate-code.py
+++ b/generate-code.py
@@ -48,7 +48,6 @@ def generate_clients(jar_path):
             -e pebble \
             -g line-bot-sdk-php-generator \
             -o {output_path} \
-            --http-user-agent LINE-BotSDK-PHP/11 \
             --additional-properties="invokerPackage={component['invokerPackage']}" \
             --additional-properties="variableNamingConvention=camelCase" \
             --additional-properties="copyrightYear={COPYRIGHT_YEAR}"

--- a/generator/src/main/resources/line-bot-sdk-php-generator/Configuration.pebble
+++ b/generator/src/main/resources/line-bot-sdk-php-generator/Configuration.pebble
@@ -88,7 +88,7 @@ class Configuration
     protected $host = '{{ basePath }}';
 
     /**
-     * User agent of the HTTP request, set to "OpenAPI-Generator/{version}/PHP" by default
+     * User agent of the HTTP request
      *
      * @var string
      */

--- a/generator/src/main/resources/line-bot-sdk-php-generator/Configuration.pebble
+++ b/generator/src/main/resources/line-bot-sdk-php-generator/Configuration.pebble
@@ -92,7 +92,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = '{% if httpUserAgent %}{{ httpUserAgent }}{% else %}OpenAPI-Generator/{% if artifactVersion %}{{ artifactVersion }}{% else %}1.0.0{% endif %}/PHP{% endif %}';
+    protected $userAgent = 'LINE-BotSDK-PHP';
 
     /**
      * Debug switch (default set to false)
@@ -135,6 +135,7 @@ class Configuration
     public function __construct()
     {
         $this->tempFolderPath = sys_get_temp_dir();
+        $this->userAgent = \LINE\Constants\SdkUserAgent::create();
     }
 
     /**

--- a/src/clients/channel-access-token/lib/Configuration.php
+++ b/src/clients/channel-access-token/lib/Configuration.php
@@ -115,7 +115,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = 'LINE-BotSDK-PHP/11';
+    protected $userAgent = 'LINE-BotSDK-PHP';
 
     /**
      * Debug switch (default set to false)
@@ -158,6 +158,7 @@ class Configuration
     public function __construct()
     {
         $this->tempFolderPath = sys_get_temp_dir();
+        $this->userAgent = \LINE\Constants\SdkUserAgent::create();
     }
 
     /**

--- a/src/clients/channel-access-token/lib/Configuration.php
+++ b/src/clients/channel-access-token/lib/Configuration.php
@@ -111,7 +111,7 @@ class Configuration
     protected $host = 'https://api.line.me';
 
     /**
-     * User agent of the HTTP request, set to "OpenAPI-Generator/{version}/PHP" by default
+     * User agent of the HTTP request
      *
      * @var string
      */

--- a/src/clients/insight/lib/Configuration.php
+++ b/src/clients/insight/lib/Configuration.php
@@ -115,7 +115,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = 'LINE-BotSDK-PHP/11';
+    protected $userAgent = 'LINE-BotSDK-PHP';
 
     /**
      * Debug switch (default set to false)
@@ -158,6 +158,7 @@ class Configuration
     public function __construct()
     {
         $this->tempFolderPath = sys_get_temp_dir();
+        $this->userAgent = \LINE\Constants\SdkUserAgent::create();
     }
 
     /**

--- a/src/clients/insight/lib/Configuration.php
+++ b/src/clients/insight/lib/Configuration.php
@@ -111,7 +111,7 @@ class Configuration
     protected $host = 'https://api.line.me';
 
     /**
-     * User agent of the HTTP request, set to "OpenAPI-Generator/{version}/PHP" by default
+     * User agent of the HTTP request
      *
      * @var string
      */

--- a/src/clients/liff/lib/Configuration.php
+++ b/src/clients/liff/lib/Configuration.php
@@ -115,7 +115,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = 'LINE-BotSDK-PHP/11';
+    protected $userAgent = 'LINE-BotSDK-PHP';
 
     /**
      * Debug switch (default set to false)
@@ -158,6 +158,7 @@ class Configuration
     public function __construct()
     {
         $this->tempFolderPath = sys_get_temp_dir();
+        $this->userAgent = \LINE\Constants\SdkUserAgent::create();
     }
 
     /**

--- a/src/clients/liff/lib/Configuration.php
+++ b/src/clients/liff/lib/Configuration.php
@@ -111,7 +111,7 @@ class Configuration
     protected $host = 'https://api.line.me';
 
     /**
-     * User agent of the HTTP request, set to "OpenAPI-Generator/{version}/PHP" by default
+     * User agent of the HTTP request
      *
      * @var string
      */

--- a/src/clients/manage-audience/lib/Configuration.php
+++ b/src/clients/manage-audience/lib/Configuration.php
@@ -115,7 +115,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = 'LINE-BotSDK-PHP/11';
+    protected $userAgent = 'LINE-BotSDK-PHP';
 
     /**
      * Debug switch (default set to false)
@@ -158,6 +158,7 @@ class Configuration
     public function __construct()
     {
         $this->tempFolderPath = sys_get_temp_dir();
+        $this->userAgent = \LINE\Constants\SdkUserAgent::create();
     }
 
     /**

--- a/src/clients/manage-audience/lib/Configuration.php
+++ b/src/clients/manage-audience/lib/Configuration.php
@@ -111,7 +111,7 @@ class Configuration
     protected $host = 'https://api.line.me';
 
     /**
-     * User agent of the HTTP request, set to "OpenAPI-Generator/{version}/PHP" by default
+     * User agent of the HTTP request
      *
      * @var string
      */

--- a/src/clients/messaging-api/lib/Configuration.php
+++ b/src/clients/messaging-api/lib/Configuration.php
@@ -115,7 +115,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = 'LINE-BotSDK-PHP/11';
+    protected $userAgent = 'LINE-BotSDK-PHP';
 
     /**
      * Debug switch (default set to false)
@@ -158,6 +158,7 @@ class Configuration
     public function __construct()
     {
         $this->tempFolderPath = sys_get_temp_dir();
+        $this->userAgent = \LINE\Constants\SdkUserAgent::create();
     }
 
     /**

--- a/src/clients/messaging-api/lib/Configuration.php
+++ b/src/clients/messaging-api/lib/Configuration.php
@@ -111,7 +111,7 @@ class Configuration
     protected $host = 'https://api.line.me';
 
     /**
-     * User agent of the HTTP request, set to "OpenAPI-Generator/{version}/PHP" by default
+     * User agent of the HTTP request
      *
      * @var string
      */

--- a/src/constants/SdkUserAgent.php
+++ b/src/constants/SdkUserAgent.php
@@ -32,7 +32,7 @@ class SdkUserAgent
     private static ?string $cached = null;
 
     /**
-     * @param null|callable(): string $versionResolver
+     * @param null|callable(): ?string $versionResolver
      */
     public static function create(?callable $versionResolver = null): string
     {
@@ -41,7 +41,7 @@ class SdkUserAgent
         }
 
         if (self::$cached === null) {
-            self::$cached = self::build(static function (): string {
+            self::$cached = self::build(static function (): ?string {
                 return InstalledVersions::getPrettyVersion(self::PACKAGE);
             });
         }
@@ -58,13 +58,17 @@ class SdkUserAgent
     }
 
     /**
-     * @param callable(): string $versionResolver
+     * @param callable(): ?string $versionResolver
      */
     private static function build(callable $versionResolver): string
     {
         try {
             $version = $versionResolver();
         } catch (\Throwable) {
+            return self::FALLBACK;
+        }
+
+        if ($version === null) {
             return self::FALLBACK;
         }
 

--- a/src/constants/SdkUserAgent.php
+++ b/src/constants/SdkUserAgent.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Copyright 2026 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace LINE\Constants;
+
+use Composer\InstalledVersions;
+
+/**
+ * @internal
+ */
+class SdkUserAgent
+{
+    private const PRODUCT = 'LINE-BotSDK-PHP';
+    private const PACKAGE = 'linecorp/line-bot-sdk';
+
+    private static ?string $cached = null;
+
+    /**
+     * @param null|callable(): ?string $versionResolver
+     */
+    public static function create(?callable $versionResolver = null): string
+    {
+        if ($versionResolver !== null) {
+            return self::build($versionResolver);
+        }
+
+        if (self::$cached === null) {
+            self::$cached = self::build(static function (): ?string {
+                return InstalledVersions::getPrettyVersion(self::PACKAGE);
+            });
+        }
+
+        return self::$cached;
+    }
+
+    /**
+     * @internal
+     */
+    public static function resetForTesting(): void
+    {
+        self::$cached = null;
+    }
+
+    /**
+     * @param callable(): ?string $versionResolver
+     */
+    private static function build(callable $versionResolver): string
+    {
+        try {
+            $version = $versionResolver();
+        } catch (\OutOfBoundsException) {
+            return self::PRODUCT;
+        }
+
+        if ($version === null || trim($version) === '') {
+            return self::PRODUCT;
+        }
+
+        $version = trim($version);
+        $version = preg_replace('/^v(?=\d)/', '', $version) ?? $version;
+        $version = preg_replace('/[^A-Za-z0-9!#$%&\'*+.^_`|~-]/', '-', $version) ?? '';
+
+        if ($version === '' || $version === '-') {
+            return self::PRODUCT;
+        }
+
+        return self::PRODUCT . '/' . $version;
+    }
+}

--- a/src/constants/SdkUserAgent.php
+++ b/src/constants/SdkUserAgent.php
@@ -26,12 +26,13 @@ use Composer\InstalledVersions;
 class SdkUserAgent
 {
     private const PRODUCT = 'LINE-BotSDK-PHP';
+    private const FALLBACK = self::PRODUCT . '/unknown';
     private const PACKAGE = 'linecorp/line-bot-sdk';
 
     private static ?string $cached = null;
 
     /**
-     * @param null|callable(): ?string $versionResolver
+     * @param null|callable(): string $versionResolver
      */
     public static function create(?callable $versionResolver = null): string
     {
@@ -40,7 +41,7 @@ class SdkUserAgent
         }
 
         if (self::$cached === null) {
-            self::$cached = self::build(static function (): ?string {
+            self::$cached = self::build(static function (): string {
                 return InstalledVersions::getPrettyVersion(self::PACKAGE);
             });
         }
@@ -57,27 +58,17 @@ class SdkUserAgent
     }
 
     /**
-     * @param callable(): ?string $versionResolver
+     * @param callable(): string $versionResolver
      */
     private static function build(callable $versionResolver): string
     {
         try {
             $version = $versionResolver();
         } catch (\OutOfBoundsException) {
-            return self::PRODUCT;
+            return self::FALLBACK;
         }
 
-        if ($version === null || trim($version) === '') {
-            return self::PRODUCT;
-        }
-
-        $version = trim($version);
         $version = preg_replace('/^v(?=\d)/', '', $version) ?? $version;
-        $version = preg_replace('/[^A-Za-z0-9!#$%&\'*+.^_`|~-]/', '-', $version) ?? '';
-
-        if ($version === '' || $version === '-') {
-            return self::PRODUCT;
-        }
 
         return self::PRODUCT . '/' . $version;
     }

--- a/src/constants/SdkUserAgent.php
+++ b/src/constants/SdkUserAgent.php
@@ -64,7 +64,7 @@ class SdkUserAgent
     {
         try {
             $version = $versionResolver();
-        } catch (\OutOfBoundsException) {
+        } catch (\Throwable) {
             return self::FALLBACK;
         }
 

--- a/src/webhook/lib/Configuration.php
+++ b/src/webhook/lib/Configuration.php
@@ -115,7 +115,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = 'OpenAPI-Generator/1.0.0/PHP';
+    protected $userAgent = 'LINE-BotSDK-PHP';
 
     /**
      * Debug switch (default set to false)
@@ -158,6 +158,7 @@ class Configuration
     public function __construct()
     {
         $this->tempFolderPath = sys_get_temp_dir();
+        $this->userAgent = \LINE\Constants\SdkUserAgent::create();
     }
 
     /**

--- a/src/webhook/lib/Configuration.php
+++ b/src/webhook/lib/Configuration.php
@@ -111,7 +111,7 @@ class Configuration
     protected $host = 'https://example.com';
 
     /**
-     * User agent of the HTTP request, set to "OpenAPI-Generator/{version}/PHP" by default
+     * User agent of the HTTP request
      *
      * @var string
      */

--- a/test/clients/ConfigurationUserAgentTest.php
+++ b/test/clients/ConfigurationUserAgentTest.php
@@ -24,6 +24,11 @@ use PHPUnit\Framework\TestCase;
 
 class ConfigurationUserAgentTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        SdkUserAgent::resetForTesting();
+    }
+
     /**
      * @param class-string $configurationClass
      */

--- a/test/clients/ConfigurationUserAgentTest.php
+++ b/test/clients/ConfigurationUserAgentTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Copyright 2026 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace LINE\Tests\Clients;
+
+use LINE\Constants\SdkUserAgent;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class ConfigurationUserAgentTest extends TestCase
+{
+    /**
+     * @param class-string $configurationClass
+     */
+    #[DataProvider('configurationClassProvider')]
+    public function testDefaultUserAgent(string $configurationClass): void
+    {
+        self::assertSame(
+            SdkUserAgent::create(),
+            (new $configurationClass())->getUserAgent(),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{class-string}>
+     */
+    public static function configurationClassProvider(): iterable
+    {
+        yield 'ChannelAccessToken' => [\LINE\Clients\ChannelAccessToken\Configuration::class];
+        yield 'Insight' => [\LINE\Clients\Insight\Configuration::class];
+        yield 'Liff' => [\LINE\Clients\Liff\Configuration::class];
+        yield 'ManageAudience' => [\LINE\Clients\ManageAudience\Configuration::class];
+        yield 'MessagingApi' => [\LINE\Clients\MessagingApi\Configuration::class];
+        yield 'Webhook' => [\LINE\Webhook\Configuration::class];
+    }
+
+    public function testSetUserAgentOverride(): void
+    {
+        $config = new \LINE\Clients\MessagingApi\Configuration();
+        $config->setUserAgent('custom-user-agent');
+        self::assertSame('custom-user-agent', $config->getUserAgent());
+    }
+}

--- a/test/clients/UserAgentHeaderTest.php
+++ b/test/clients/UserAgentHeaderTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Copyright 2026 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace LINE\Tests\Clients;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use LINE\Clients\MessagingApi\Api\MessagingApiApi;
+use LINE\Clients\MessagingApi\Configuration;
+use LINE\Constants\SdkUserAgent;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class UserAgentHeaderTest extends TestCase
+{
+    public function testDefaultUserAgentHeader(): void
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('send')
+            ->with(
+                Mockery::on(function (Request $request) {
+                    $this->assertSame(
+                        SdkUserAgent::create(),
+                        $request->getHeaderLine('User-Agent'),
+                    );
+                    return true;
+                }),
+                []
+            )
+            ->once()
+            ->andReturn(new Response(
+                status: 200,
+                headers: [],
+                body: json_encode(['userIds' => [], 'next' => null]),
+            ));
+
+        $api = new MessagingApiApi($client);
+        $api->getFollowers();
+    }
+
+    public function testCustomUserAgentHeader(): void
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('send')
+            ->with(
+                Mockery::on(function (Request $request) {
+                    $this->assertSame(
+                        'custom-user-agent',
+                        $request->getHeaderLine('User-Agent'),
+                    );
+                    return true;
+                }),
+                []
+            )
+            ->once()
+            ->andReturn(new Response(
+                status: 200,
+                headers: [],
+                body: json_encode(['userIds' => [], 'next' => null]),
+            ));
+
+        $config = new Configuration();
+        $config->setUserAgent('custom-user-agent');
+        $api = new MessagingApiApi($client, $config);
+        $api->getFollowers();
+    }
+}

--- a/test/constants/SdkUserAgentTest.php
+++ b/test/constants/SdkUserAgentTest.php
@@ -19,7 +19,6 @@
 namespace LINE\Tests\Constants;
 
 use LINE\Constants\SdkUserAgent;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class SdkUserAgentTest extends TestCase
@@ -29,26 +28,14 @@ class SdkUserAgentTest extends TestCase
         SdkUserAgent::resetForTesting();
     }
 
-    #[DataProvider('versionProvider')]
-    public function testCreate(?string $input, string $expected): void
+    public function testStableVersion(): void
     {
-        self::assertSame($expected, SdkUserAgent::create(fn () => $input));
+        self::assertSame('LINE-BotSDK-PHP/12.5.0', SdkUserAgent::create(fn () => '12.5.0'));
     }
 
-    /**
-     * @return iterable<string, array{?string, string}>
-     */
-    public static function versionProvider(): iterable
+    public function testStripsLeadingV(): void
     {
-        yield 'stable' => ['12.5.0', 'LINE-BotSDK-PHP/12.5.0'];
-        yield 'v-prefix' => ['v12.5.0', 'LINE-BotSDK-PHP/12.5.0'];
-        yield 'pre-release' => ['12.5.0-beta.1', 'LINE-BotSDK-PHP/12.5.0-beta.1'];
-        yield 'build-metadata' => ['12.5.0+build.7', 'LINE-BotSDK-PHP/12.5.0+build.7'];
-        yield 'dev-branch' => ['dev-main', 'LINE-BotSDK-PHP/dev-main'];
-        yield 'dev-branch-slash' => ['dev-feature/user-agent', 'LINE-BotSDK-PHP/dev-feature-user-agent'];
-        yield 'null' => [null, 'LINE-BotSDK-PHP'];
-        yield 'empty' => ['', 'LINE-BotSDK-PHP'];
-        yield 'whitespace' => ['   ', 'LINE-BotSDK-PHP'];
+        self::assertSame('LINE-BotSDK-PHP/12.5.0', SdkUserAgent::create(fn () => 'v12.5.0'));
     }
 
     public function testOutOfBoundsExceptionFallback(): void
@@ -56,16 +43,6 @@ class SdkUserAgentTest extends TestCase
         $result = SdkUserAgent::create(function (): never {
             throw new \OutOfBoundsException('Package not found');
         });
-        self::assertSame('LINE-BotSDK-PHP', $result);
-    }
-
-    public function testCustomResolverBypassesCache(): void
-    {
-        SdkUserAgent::create(fn () => '1.0.0');
-
-        self::assertSame(
-            'LINE-BotSDK-PHP/99.0.0',
-            SdkUserAgent::create(fn () => '99.0.0'),
-        );
+        self::assertSame('LINE-BotSDK-PHP/unknown', $result);
     }
 }

--- a/test/constants/SdkUserAgentTest.php
+++ b/test/constants/SdkUserAgentTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Copyright 2026 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace LINE\Tests\Constants;
+
+use LINE\Constants\SdkUserAgent;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class SdkUserAgentTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        SdkUserAgent::resetForTesting();
+    }
+
+    #[DataProvider('versionProvider')]
+    public function testCreate(?string $input, string $expected): void
+    {
+        self::assertSame($expected, SdkUserAgent::create(fn () => $input));
+    }
+
+    /**
+     * @return iterable<string, array{?string, string}>
+     */
+    public static function versionProvider(): iterable
+    {
+        yield 'stable' => ['12.5.0', 'LINE-BotSDK-PHP/12.5.0'];
+        yield 'v-prefix' => ['v12.5.0', 'LINE-BotSDK-PHP/12.5.0'];
+        yield 'pre-release' => ['12.5.0-beta.1', 'LINE-BotSDK-PHP/12.5.0-beta.1'];
+        yield 'build-metadata' => ['12.5.0+build.7', 'LINE-BotSDK-PHP/12.5.0+build.7'];
+        yield 'dev-branch' => ['dev-main', 'LINE-BotSDK-PHP/dev-main'];
+        yield 'dev-branch-slash' => ['dev-feature/user-agent', 'LINE-BotSDK-PHP/dev-feature-user-agent'];
+        yield 'null' => [null, 'LINE-BotSDK-PHP'];
+        yield 'empty' => ['', 'LINE-BotSDK-PHP'];
+        yield 'whitespace' => ['   ', 'LINE-BotSDK-PHP'];
+    }
+
+    public function testOutOfBoundsExceptionFallback(): void
+    {
+        $result = SdkUserAgent::create(function (): never {
+            throw new \OutOfBoundsException('Package not found');
+        });
+        self::assertSame('LINE-BotSDK-PHP', $result);
+    }
+
+    public function testCustomResolverBypassesCache(): void
+    {
+        SdkUserAgent::create(fn () => '1.0.0');
+
+        self::assertSame(
+            'LINE-BotSDK-PHP/99.0.0',
+            SdkUserAgent::create(fn () => '99.0.0'),
+        );
+    }
+}

--- a/test/constants/SdkUserAgentTest.php
+++ b/test/constants/SdkUserAgentTest.php
@@ -38,10 +38,10 @@ class SdkUserAgentTest extends TestCase
         self::assertSame('LINE-BotSDK-PHP/12.5.0', SdkUserAgent::create(fn () => 'v12.5.0'));
     }
 
-    public function testOutOfBoundsExceptionFallback(): void
+    public function testExceptionFallback(): void
     {
         $result = SdkUserAgent::create(function (): never {
-            throw new \OutOfBoundsException('Package not found');
+            throw new \RuntimeException('unexpected error');
         });
         self::assertSame('LINE-BotSDK-PHP/unknown', $result);
     }


### PR DESCRIPTION
Currently, the user agent value is hardcoded as `LINE-BotSDK-PHP/11`, even though the actual SDK version has been 12 for some time.

Since it's easy to forget updating this value like current situation, let's retrieve the SDK version at runtime, as the other bot sdks do.

This usage is explicitly supported and allowed by the Composer API.
- https://getcomposer.org/doc/07-runtime.md#installed-versions