### PR TITLE
Add and manage guide documentation

### DIFF
--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Generate codes
         run: python generate-code.py
+      - name: Install dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
       - name: Update document
         run: composer docs
       - run: |
@@ -112,7 +114,7 @@ jobs:
           
           git add docs/**
           git commit --allow-empty -m "Update document"
-          
+
           git push origin $BRANCH_NAME
 
           gh pr create -B ${{ github.ref_name }} -H $BRANCH_NAME -t "$TITLE" -b "$BODY" --label "line-openapi-update"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,26 +12,60 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pages: write
-      id-token: write
       issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: '8.2'
+      - name: Install dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - name: Build documentation
+        run: composer docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          path: 'docs'
+          path: build/site
+
+      - name: Create GitHub Issue on Failure
+        if: failure()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issueTitle = `build-page job failed`;
+            const issueBody = `The build-page job failed. Please check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.`;
+            const assignees = [context.actor];
+
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title: issueTitle,
+              body: issueBody,
+              assignees
+            });
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+      issues: write
+    name: Deploy
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ composer.phar
 *.iml
 vendor/
 /.phpdoc/
+/build/
 phpDocumentor.phar
 .phpunit.result.cache
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,6 @@ The project structure is as follows:
 - `generator`: Custom OpenAPI Generator codegen with Pebble templates for code generation.
 - `support/docs`: Hand-written guide sources (reStructuredText) for phpDocumentor Guides.
 - `build/site`: Auto-generated documentation output (not committed).
-- `.github/workflows/deploy-docs.yml`: Documentation deploy workflow (GitHub Pages).
 
 ### Edit OpenAPI templates
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,9 @@ The project structure is as follows:
 - `examples`: Example projects that use the library.
 - `tools`: Development tools including copyright checking scripts.
 - `generator`: Custom OpenAPI Generator codegen with Pebble templates for code generation.
-- `docs`: Auto-generated [Documentation](https://line.github.io/line-bot-sdk-php/) files by phpDocumentor.
+- `support/docs`: Hand-written guide sources (reStructuredText) for phpDocumentor Guides.
+- `build/site`: Auto-generated documentation output (not committed).
+- `.github/workflows/deploy-docs.yml`: Documentation deploy workflow (GitHub Pages).
 
 ### Edit OpenAPI templates
 
@@ -65,24 +67,32 @@ Run `composer check` to check comprehensively. Following tests will run.
 
 https://line.github.io/line-bot-sdk-php/
 
-We use [phpDocumentor](https://www.phpdoc.org/) to generate API documentation.
+We use [phpDocumentor](https://www.phpdoc.org/) to generate API documentation and hand-written guides.
 **Please make sure your new or modified code is covered by proper PHPDoc comments.**
-Good documentation ensures that contributors and users can easily read and understand how the methods and classes work.
 
-**Important:** You **must** regenerate and commit the documentation after modifying code in `src/` or merging from `master`. The CI will fail if documentation is out of sync.
-
-To generate documentation locally, run:
+To generate documentation locally:
 
 ```bash
-$ composer docs
+composer docs
 ```
 
-Or manually:
+This generates the site under `build/site/`. To preview in a browser:
 
 ```bash
-$ wget https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.8.1/phpDocumentor.phar
-$ php phpDocumentor.phar run -d src -t docs
+php -S 127.0.0.1:8000 -t build/site
 ```
+
+Then open http://127.0.0.1:8000/.
+
+#### Documentation structure
+
+| Path | Content |
+|---|---|
+| `support/docs/` | Hand-written guide sources (reStructuredText) |
+| `phpdoc.dist.xml` | phpDocumentor configuration |
+| `build/site/` | Generated output (not committed) |
+
+The generated site contains API docs at the root (`/classes/`, `/namespaces/`, etc.) and hand-written guides under `/docs/`.
 
 ## Contributor license agreement
 

--- a/README.md
+++ b/README.md
@@ -162,11 +162,12 @@ A full-stack (and slightly complex) sample implementation. This application demo
 ### PHPDoc
 https://line.github.io/line-bot-sdk-php/
 
-This library provides PHPDoc to describe how to use the methods. You can generate the documentation using phpDocumenter using the following command.
+This library provides PHPDoc to describe how to use the methods. You can generate the documentation locally:
 
-$ wget https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.8.1/phpDocumentor.phar
-$ php phpDocumentor.phar run -d src -t docs
-The HTML files are generated in docs/.
+```bash
+composer docs
+php -S 127.0.0.1:8000 -t build/site
+```
 
 ### Official API documentation
 

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "squizlabs/php_codesniffer": "4.0.1",
     "orchestra/testbench": "*",
     "phpstan/phpstan": "^2.0",
+    "phpdocumentor/shim": "3.10.0",
     "phpunit/phpunit": "^11.0"
   },
   "autoload": {
@@ -84,6 +85,11 @@
         "LINEMessagingApi": "LINE\\Laravel\\Facades\\LINEMessagingApi",
         "LINEMessagingBlobApi": "LINE\\Laravel\\Facades\\LINEMessagingBlobApi"
       }
+    }
+  },
+  "config": {
+    "allow-plugins": {
+      "phpdocumentor/shim": true
     }
   }
 }

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -3,14 +3,16 @@
         configVersion="3"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="https://www.phpdoc.org"
-        xsi:noNamespaceSchemaLocation="data/xsd/phpdoc.xsd"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/phpDocumentor/phpDocumentor/master/data/xsd/phpdoc.xsd"
 >
     <title>LINE Messaging API SDK for PHP</title>
+
     <paths>
-        <output>docs</output>
+        <output>build/site</output>
+        <cache>build/cache</cache>
     </paths>
+
     <version number="latest">
-        <folder>latest</folder>
         <api>
             <source dsn=".">
                 <path>src</path>
@@ -23,6 +25,14 @@
                 <extension>php</extension>
             </extensions>
         </api>
+
+        <guide format="rst">
+            <source dsn=".">
+                <path>support/docs</path>
+            </source>
+            <output>docs</output>
+        </guide>
     </version>
+
     <template name="default"/>
 </phpdocumentor>

--- a/support/docs/error-handling.rst
+++ b/support/docs/error-handling.rst
@@ -1,0 +1,32 @@
+Error handling
+==============
+
+Catching exceptions
+-------------------
+
+Each API client defines its own exception class.
+For ``MessagingApiApi``, catch ``\LINE\Clients\MessagingApi\ApiException``:
+
+.. code-block:: php
+
+   use LINE\Clients\MessagingApi\ApiException;
+
+   try {
+       $profile = $messagingApi->getProfile($userId);
+   } catch (ApiException $e) {
+       $httpStatusCode = $e->getCode();
+       $errorMessage = $e->getResponseBody();
+       $headers = $e->getResponseHeaders();
+       $requestId = $headers['x-line-request-id'][0] ?? null;
+   }
+
+Getting response headers
+------------------------
+
+Use ``*WithHttpInfo`` methods to access response headers and status codes:
+
+.. code-block:: php
+
+   [$body, $statusCode, $headers] = $messagingApi->replyMessageWithHttpInfo($request);
+
+   $requestId = $headers['x-line-request-id'][0];

--- a/support/docs/getting-started.rst
+++ b/support/docs/getting-started.rst
@@ -1,0 +1,64 @@
+Getting started
+===============
+
+Requirements
+------------
+
+- PHP 8.2 or later
+- `Composer <https://getcomposer.org/>`_
+
+Installation
+------------
+
+.. code-block:: bash
+
+   composer require linecorp/line-bot-sdk
+
+Create a client
+---------------
+
+.. code-block:: php
+
+   use GuzzleHttp\Client;
+   use LINE\Clients\MessagingApi\Configuration;
+   use LINE\Clients\MessagingApi\Api\MessagingApiApi;
+
+   $client = new Client();
+   $config = new Configuration();
+   $config->setAccessToken('<channel access token>');
+   $messagingApi = new MessagingApiApi(
+       client: $client,
+       config: $config,
+   );
+
+Send a reply
+------------
+
+.. code-block:: php
+
+   use LINE\Clients\MessagingApi\Model\TextMessage;
+   use LINE\Clients\MessagingApi\Model\ReplyMessageRequest;
+
+   $message = new TextMessage(['text' => 'hello!']);
+   $request = new ReplyMessageRequest([
+       'replyToken' => '<reply token>',
+       'messages' => [$message],
+   ]);
+   $messagingApi->replyMessage($request);
+
+Setter style is also supported:
+
+.. code-block:: php
+
+   $message = (new TextMessage())
+       ->setText('hello!');
+   $request = (new ReplyMessageRequest())
+       ->setReplyToken('<reply token>')
+       ->setMessages([$message]);
+   $messagingApi->replyMessage($request);
+
+Examples
+--------
+
+- `EchoBot <https://github.com/line/line-bot-sdk-php/tree/master/examples/EchoBot>`_ — Replies to text messages from users.
+- `KitchenSink <https://github.com/line/line-bot-sdk-php/tree/master/examples/KitchenSink>`_ — Demonstrates practical use of the Messaging API.

--- a/support/docs/index.rst
+++ b/support/docs/index.rst
@@ -1,0 +1,12 @@
+Guides
+======
+
+Hand-written documentation for the LINE Messaging API SDK for PHP.
+
+.. toctree::
+   :maxdepth: 2
+
+   getting-started
+   webhook
+   error-handling
+   laravel

--- a/support/docs/laravel.rst
+++ b/support/docs/laravel.rst
@@ -1,0 +1,43 @@
+Laravel integration
+===================
+
+This SDK includes a Laravel service provider with facades.
+
+Setup
+-----
+
+Add your channel access token to ``.env``:
+
+.. code-block:: text
+
+   LINE_BOT_CHANNEL_ACCESS_TOKEN=<Channel Access Token>
+
+Then use the facades directly:
+
+.. code-block:: php
+
+   \LINEMessagingApi::pushMessage($request);
+
+Custom configuration
+--------------------
+
+To customize the HTTP client configuration, publish the config file:
+
+.. code-block:: bash
+
+   php artisan vendor:publish --provider="LINE\Laravel\LINEBotServiceProvider" --tag=config
+
+This creates ``config/line-bot.php``:
+
+.. code-block:: php
+
+   return [
+       'channel_access_token' => env('LINE_BOT_CHANNEL_ACCESS_TOKEN'),
+       'channel_id' => env('LINE_BOT_CHANNEL_ID'),
+       'channel_secret' => env('LINE_BOT_CHANNEL_SECRET'),
+       'client' => [
+           'config' => [
+               'headers' => ['X-Foo' => 'Bar'],
+           ],
+       ],
+   ];

--- a/support/docs/webhook.rst
+++ b/support/docs/webhook.rst
@@ -1,0 +1,30 @@
+Webhook
+=======
+
+LINE's server sends user actions (messages, images, locations, etc.) to your bot server as webhook events.
+
+Handling webhooks
+-----------------
+
+1. Receive the webhook request from LINE.
+2. Parse the request body with ``EventRequestParser``.
+3. Handle each event.
+
+.. code-block:: php
+
+   use LINE\Parser\EventRequestParser;
+
+   $events = EventRequestParser::parseEventRequest(
+       $body,
+       $channelSecret,
+       $signature,
+   );
+
+   foreach ($events as $event) {
+       // Handle event
+   }
+
+See the example implementations:
+
+- `EchoBot: Route.php <https://github.com/line/line-bot-sdk-php/blob/master/examples/EchoBot/src/LINEBot/EchoBot/Route.php>`_
+- `KitchenSink: Route.php <https://github.com/line/line-bot-sdk-php/blob/master/examples/KitchenSink/src/LINEBot/KitchenSink/Route.php>`_

--- a/support/docs/webhook.rst
+++ b/support/docs/webhook.rst
@@ -14,13 +14,13 @@ Handling webhooks
 
    use LINE\Parser\EventRequestParser;
 
-   $events = EventRequestParser::parseEventRequest(
+   $parsedEvents = EventRequestParser::parseEventRequest(
        $body,
        $channelSecret,
        $signature,
    );
 
-   foreach ($events as $event) {
+   foreach ($parsedEvents->getEvents() as $event) {
        // Handle event
    }
 

--- a/tools/docs.sh
+++ b/tools/docs.sh
@@ -1,15 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-PHPDOC_VERSION="v3.8.1"
-PHPDOC_URL="https://github.com/phpDocumentor/phpDocumentor/releases/download/${PHPDOC_VERSION}/phpDocumentor.phar"
-PHPDOC_SHA256="aa00973d88b278fe59fd8dce826d8d5419df589cb7563ac379856ec305d6b938"
+rm -rf build/site build/cache
 
-if [ ! -f phpDocumentor.phar ]; then
-  curl -L -o phpDocumentor.phar "$PHPDOC_URL"
-  echo "$PHPDOC_SHA256  phpDocumentor.phar" | shasum -a 256 -c || {
-    rm -f phpDocumentor.phar
-    exit 1
-  }
-fi
-
-php phpDocumentor.phar run -d src -t docs
+vendor/bin/phpdoc run --config=phpdoc.dist.xml


### PR DESCRIPTION
I've found PhpDocumentor provides `Hand written documentation`. 
- https://docs.phpdoc.org/guide/hand-written-docs/index.html

Current our docs is generated based on only php code, which is not helpful for beginners.
Let's add guide that is written manually, like other bot sdks.

The manual page is merged into docs on build by PhpDocumentor automatically, and preview is here: 

<img width="1023" height="801" alt="スクリーンショット 2026-07-02 10 17 58" src="https://github.com/user-attachments/assets/c3897580-c748-422f-912e-5c4e8c2c98a5" />
<img width="1331" height="804" alt="image" src="https://github.com/user-attachments/assets/3a4fce48-9e67-4716-9bb3-b2b0d4795db5" />


As a first step, let's try to build page without `docs` dir. I've already tested in my local.
Next PR removes `docs` dir (https://github.com/line/line-bot-sdk-php/pull/859), which is noisy on creating PR.

(part of https://github.com/line/line-bot-sdk-php/issues/854)