### PR TITLE
Inject missing urls in ToC forcibly

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,3 +10,6 @@ Hand-written documentation for the LINE Messaging API SDK for PHP.
    webhook
    error-handling
    laravel
+
+.. When adding a new page here, also update tools/docs.sh to include it in the
+   top-page Table of Contents.

--- a/tools/docs.sh
+++ b/tools/docs.sh
@@ -4,3 +4,40 @@ set -euo pipefail
 rm -rf build/site build/cache
 
 vendor/bin/phpdoc run --config=phpdoc.dist.xml
+
+# Inject extra ToC sections into index.html
+sed -i.bak '/<h4 id="packages">/i\
+<h4 id="guides">Guides</h4>\
+<dl class="phpdocumentor-table-of-contents">\
+    <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="docs/getting-started.html">Getting started</a></dt>\
+    <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="docs/webhook.html">Webhook</a></dt>\
+    <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="docs/error-handling.html">Error handling</a></dt>\
+    <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="docs/laravel.html">Laravel integration</a></dt>\
+</dl>\
+
+' build/site/index.html
+rm -f build/site/index.html.bak
+
+sed -i.bak '
+/phpdocumentor-table-of-contents__entry -namespace.*namespaces\/line\.html/,/<\/dl>/ {
+    /<\/dl>/a\
+\
+<h4 id="reports">Reports</h4>\
+<dl class="phpdocumentor-table-of-contents">\
+    <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="reports/deprecated.html">Deprecated</a></dt>\
+    <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="reports/errors.html">Errors</a></dt>\
+    <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="reports/markers.html">Markers</a></dt>\
+</dl>\
+\
+<h4 id="indices">Indices</h4>\
+<dl class="phpdocumentor-table-of-contents">\
+    <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="indices/files.html">Files</a></dt>\
+</dl>\
+\
+<h4 id="links">Links</h4>\
+<dl class="phpdocumentor-table-of-contents">\
+    <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="https://github.com/line/line-bot-sdk-php">GitHub</a></dt>\
+</dl>
+}
+' build/site/index.html
+rm -f build/site/index.html.bak


### PR DESCRIPTION
When we open https://line.github.io/line-bot-sdk-php/, the sidebar sections are shown on the generated pages, but not on the main page.

This doesn't seem to be configurable with phpDocumentor, so this change injects it manually.

The page structure rarely changes, so the maintenance cost should be low enough to justify this workaround.

asis
<img width="618" height="769" alt="image" src="https://github.com/user-attachments/assets/253d731b-6489-41be-b1ac-9e4e6a762b72" />



tobe

<img width="549" height="791" alt="image" src="https://github.com/user-attachments/assets/33fa0f37-1c3d-4d80-8d13-dd1bdecc8770" />
