### PR TITLE
Support Guzzle 8 while keeping Guzzle 7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": "^8.2",
     "composer-runtime-api": "^2.0",
-    "guzzlehttp/guzzle": "^7.3",
+    "guzzlehttp/guzzle": "^8.0",
     "guzzlehttp/psr7": "^1.7 || ^2.0 || ^3.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
   "require": {
     "php": "^8.2",
     "composer-runtime-api": "^2.0",
-    "guzzlehttp/guzzle": "^8.0",
+    "guzzlehttp/guzzle": "^7.3 || ^8.0",
     "guzzlehttp/psr7": "^1.7 || ^2.0 || ^3.0"
   },
   "require-dev": {
     "phpmd/phpmd": "2.15.0",
-    "squizlabs/php_codesniffer": "4.0.1",
+    "squizlabs/php_codesniffer": "4.0.4",
     "orchestra/testbench": "*",
     "phpstan/phpstan": "^2.0",
     "phpdocumentor/shim": "3.10.0",

--- a/examples/EchoBot/composer.json
+++ b/examples/EchoBot/composer.json
@@ -32,7 +32,7 @@
     "slim/psr7": "^1.6",
     "slim/http": "^1.3",
     "monolog/monolog": "^3.0.0",
-    "guzzlehttp/guzzle": "^7.5",
+    "guzzlehttp/guzzle": "^8.0",
     "guzzlehttp/psr7": "^3.0",
     "php-di/slim-bridge": "^3.3",
     "linecorp/line-bot-sdk": "*"

--- a/examples/KitchenSink/composer.json
+++ b/examples/KitchenSink/composer.json
@@ -32,7 +32,7 @@
     "slim/psr7": "^1.6",
     "slim/http": "^1.3",
     "monolog/monolog": "^3.0.0",
-    "guzzlehttp/guzzle": "^7.5",
+    "guzzlehttp/guzzle": "^8.0",
     "guzzlehttp/psr7": "^3.0",
     "php-di/slim-bridge": "^3.3",
     "linecorp/line-bot-sdk": "*"

--- a/generator/src/main/resources/line-bot-sdk-php-generator/api.pebble
+++ b/generator/src/main/resources/line-bot-sdk-php-generator/api.pebble
@@ -20,8 +20,8 @@ namespace {{ apiPackage }};
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
@@ -229,14 +229,15 @@ class {{ operations.classname }}
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -453,17 +454,25 @@ class {{ operations.classname }}
 {%- endif %}
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -621,7 +630,7 @@ class {{ operations.classname }}
         if (isset(${{ p.paramName }})) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization(${{ p.paramName }}));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization(${{ p.paramName }}), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = ${{ p.paramName }};
             }
@@ -646,7 +655,7 @@ class {{ operations.classname }}
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);

--- a/generator/src/main/resources/line-bot-sdk-php-generator/api.pebble
+++ b/generator/src/main/resources/line-bot-sdk-php-generator/api.pebble
@@ -20,8 +20,8 @@ namespace {{ apiPackage }};
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
@@ -229,15 +229,15 @@ class {{ operations.classname }}
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -454,25 +454,27 @@ class {{ operations.classname }}
 {%- endif %}
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );

--- a/src/clients/channel-access-token/lib/Api/ChannelAccessTokenApi.php
+++ b/src/clients/channel-access-token/lib/Api/ChannelAccessTokenApi.php
@@ -41,8 +41,8 @@ namespace LINE\Clients\ChannelAccessToken\Api;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
@@ -194,15 +194,15 @@ class ChannelAccessTokenApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -315,25 +315,27 @@ class ChannelAccessTokenApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -487,15 +489,15 @@ class ChannelAccessTokenApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -624,25 +626,27 @@ class ChannelAccessTokenApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -797,15 +801,15 @@ class ChannelAccessTokenApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -920,25 +924,27 @@ class ChannelAccessTokenApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -1101,15 +1107,15 @@ class ChannelAccessTokenApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1232,25 +1238,27 @@ class ChannelAccessTokenApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -1388,15 +1396,15 @@ class ChannelAccessTokenApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1458,25 +1466,27 @@ class ChannelAccessTokenApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -1612,15 +1622,15 @@ class ChannelAccessTokenApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1686,25 +1696,27 @@ class ChannelAccessTokenApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -1855,15 +1867,15 @@ class ChannelAccessTokenApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1974,25 +1986,27 @@ class ChannelAccessTokenApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -2125,15 +2139,15 @@ class ChannelAccessTokenApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -2244,25 +2258,27 @@ class ChannelAccessTokenApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );

--- a/src/clients/channel-access-token/lib/Api/ChannelAccessTokenApi.php
+++ b/src/clients/channel-access-token/lib/Api/ChannelAccessTokenApi.php
@@ -41,8 +41,8 @@ namespace LINE\Clients\ChannelAccessToken\Api;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
@@ -194,14 +194,15 @@ class ChannelAccessTokenApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -314,17 +315,25 @@ class ChannelAccessTokenApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -411,7 +420,7 @@ class ChannelAccessTokenApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -478,14 +487,15 @@ class ChannelAccessTokenApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -614,17 +624,25 @@ class ChannelAccessTokenApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -712,7 +730,7 @@ class ChannelAccessTokenApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -779,14 +797,15 @@ class ChannelAccessTokenApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -901,17 +920,25 @@ class ChannelAccessTokenApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -999,7 +1026,7 @@ class ChannelAccessTokenApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1074,14 +1101,15 @@ class ChannelAccessTokenApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1204,17 +1232,25 @@ class ChannelAccessTokenApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -1290,7 +1326,7 @@ class ChannelAccessTokenApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1352,14 +1388,15 @@ class ChannelAccessTokenApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1421,17 +1458,25 @@ class ChannelAccessTokenApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -1501,7 +1546,7 @@ class ChannelAccessTokenApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1567,14 +1612,15 @@ class ChannelAccessTokenApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1640,17 +1686,25 @@ class ChannelAccessTokenApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -1738,7 +1792,7 @@ class ChannelAccessTokenApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1801,14 +1855,15 @@ class ChannelAccessTokenApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1919,17 +1974,25 @@ class ChannelAccessTokenApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -1999,7 +2062,7 @@ class ChannelAccessTokenApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -2062,14 +2125,15 @@ class ChannelAccessTokenApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -2180,17 +2244,25 @@ class ChannelAccessTokenApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -2260,7 +2332,7 @@ class ChannelAccessTokenApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);

--- a/src/clients/insight/lib/Api/InsightApi.php
+++ b/src/clients/insight/lib/Api/InsightApi.php
@@ -41,8 +41,8 @@ namespace LINE\Clients\Insight\Api;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
@@ -187,15 +187,15 @@ class InsightApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -304,25 +304,27 @@ class InsightApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -446,15 +448,15 @@ class InsightApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -569,25 +571,27 @@ class InsightApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -731,15 +735,15 @@ class InsightApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -854,25 +858,27 @@ class InsightApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -1016,15 +1022,15 @@ class InsightApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1139,25 +1145,27 @@ class InsightApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -1311,15 +1319,15 @@ class InsightApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1466,25 +1474,27 @@ class InsightApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -1680,15 +1690,15 @@ class InsightApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1835,25 +1845,27 @@ class InsightApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -2045,15 +2057,15 @@ class InsightApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -2168,25 +2180,27 @@ class InsightApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );

--- a/src/clients/insight/lib/Api/InsightApi.php
+++ b/src/clients/insight/lib/Api/InsightApi.php
@@ -41,8 +41,8 @@ namespace LINE\Clients\Insight\Api;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
@@ -187,14 +187,15 @@ class InsightApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -303,17 +304,25 @@ class InsightApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -366,7 +375,7 @@ class InsightApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -437,14 +446,15 @@ class InsightApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -559,17 +569,25 @@ class InsightApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -642,7 +660,7 @@ class InsightApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -713,14 +731,15 @@ class InsightApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -835,17 +854,25 @@ class InsightApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -918,7 +945,7 @@ class InsightApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -989,14 +1016,15 @@ class InsightApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1111,17 +1139,25 @@ class InsightApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -1200,7 +1236,7 @@ class InsightApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1275,14 +1311,15 @@ class InsightApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1429,17 +1466,25 @@ class InsightApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -1560,7 +1605,7 @@ class InsightApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1635,14 +1680,15 @@ class InsightApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1789,17 +1835,25 @@ class InsightApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -1920,7 +1974,7 @@ class InsightApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1991,14 +2045,15 @@ class InsightApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -2113,17 +2168,25 @@ class InsightApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -2254,7 +2317,7 @@ class InsightApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);

--- a/src/clients/liff/lib/Api/LiffApi.php
+++ b/src/clients/liff/lib/Api/LiffApi.php
@@ -41,8 +41,8 @@ namespace LINE\Clients\Liff\Api;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
@@ -184,14 +184,15 @@ class LiffApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -306,17 +307,25 @@ class LiffApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -363,7 +372,7 @@ class LiffApi
         if (isset($addLiffAppRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($addLiffAppRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($addLiffAppRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $addLiffAppRequest;
             }
@@ -384,7 +393,7 @@ class LiffApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -454,14 +463,15 @@ class LiffApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -527,17 +537,25 @@ class LiffApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -606,7 +624,7 @@ class LiffApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -675,14 +693,15 @@ class LiffApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -795,17 +814,25 @@ class LiffApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -858,7 +885,7 @@ class LiffApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -930,14 +957,15 @@ class LiffApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1005,17 +1033,25 @@ class LiffApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -1078,7 +1114,7 @@ class LiffApi
         if (isset($updateLiffAppRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($updateLiffAppRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($updateLiffAppRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $updateLiffAppRequest;
             }
@@ -1099,7 +1135,7 @@ class LiffApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);

--- a/src/clients/liff/lib/Api/LiffApi.php
+++ b/src/clients/liff/lib/Api/LiffApi.php
@@ -41,8 +41,8 @@ namespace LINE\Clients\Liff\Api;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
@@ -184,15 +184,15 @@ class LiffApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -307,25 +307,27 @@ class LiffApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -463,15 +465,15 @@ class LiffApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -537,25 +539,27 @@ class LiffApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -693,15 +697,15 @@ class LiffApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -814,25 +818,27 @@ class LiffApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -957,15 +963,15 @@ class LiffApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1033,25 +1039,27 @@ class LiffApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );

--- a/src/clients/manage-audience/lib/Api/ManageAudienceApi.php
+++ b/src/clients/manage-audience/lib/Api/ManageAudienceApi.php
@@ -41,8 +41,8 @@ namespace LINE\Clients\ManageAudience\Api;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
@@ -197,15 +197,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -267,25 +267,27 @@ class ManageAudienceApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -420,15 +422,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -539,25 +541,27 @@ class ManageAudienceApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -692,15 +696,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -811,25 +815,27 @@ class ManageAudienceApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -964,15 +970,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1083,25 +1089,27 @@ class ManageAudienceApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -1235,15 +1243,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1305,25 +1313,27 @@ class ManageAudienceApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -1459,15 +1469,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1592,25 +1602,27 @@ class ManageAudienceApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -1756,15 +1768,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1885,25 +1897,27 @@ class ManageAudienceApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -2101,15 +2115,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -2234,25 +2248,27 @@ class ManageAudienceApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -2398,15 +2414,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -2527,25 +2543,27 @@ class ManageAudienceApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -2744,15 +2762,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -2816,25 +2834,27 @@ class ManageAudienceApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );

--- a/src/clients/manage-audience/lib/Api/ManageAudienceApi.php
+++ b/src/clients/manage-audience/lib/Api/ManageAudienceApi.php
@@ -41,8 +41,8 @@ namespace LINE\Clients\ManageAudience\Api;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
@@ -197,14 +197,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -266,17 +267,25 @@ class ManageAudienceApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -323,7 +332,7 @@ class ManageAudienceApi
         if (isset($addAudienceToAudienceGroupRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($addAudienceToAudienceGroupRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($addAudienceToAudienceGroupRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $addAudienceToAudienceGroupRequest;
             }
@@ -344,7 +353,7 @@ class ManageAudienceApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -411,14 +420,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -529,17 +539,25 @@ class ManageAudienceApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -586,7 +604,7 @@ class ManageAudienceApi
         if (isset($createAudienceGroupRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($createAudienceGroupRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($createAudienceGroupRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $createAudienceGroupRequest;
             }
@@ -607,7 +625,7 @@ class ManageAudienceApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -674,14 +692,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -792,17 +811,25 @@ class ManageAudienceApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -849,7 +876,7 @@ class ManageAudienceApi
         if (isset($createClickBasedAudienceGroupRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($createClickBasedAudienceGroupRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($createClickBasedAudienceGroupRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $createClickBasedAudienceGroupRequest;
             }
@@ -870,7 +897,7 @@ class ManageAudienceApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -937,14 +964,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1055,17 +1083,25 @@ class ManageAudienceApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -1112,7 +1148,7 @@ class ManageAudienceApi
         if (isset($createImpBasedAudienceGroupRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($createImpBasedAudienceGroupRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($createImpBasedAudienceGroupRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $createImpBasedAudienceGroupRequest;
             }
@@ -1133,7 +1169,7 @@ class ManageAudienceApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1199,14 +1235,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1268,17 +1305,25 @@ class ManageAudienceApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -1347,7 +1392,7 @@ class ManageAudienceApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1414,14 +1459,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1546,17 +1592,25 @@ class ManageAudienceApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -1625,7 +1679,7 @@ class ManageAudienceApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1702,14 +1756,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1830,17 +1885,25 @@ class ManageAudienceApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -1971,7 +2034,7 @@ class ManageAudienceApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -2038,14 +2101,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -2170,17 +2234,25 @@ class ManageAudienceApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -2249,7 +2321,7 @@ class ManageAudienceApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -2326,14 +2398,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -2454,17 +2527,25 @@ class ManageAudienceApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -2595,7 +2676,7 @@ class ManageAudienceApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -2663,14 +2744,15 @@ class ManageAudienceApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -2734,17 +2816,25 @@ class ManageAudienceApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -2807,7 +2897,7 @@ class ManageAudienceApi
         if (isset($updateAudienceGroupDescriptionRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($updateAudienceGroupDescriptionRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($updateAudienceGroupDescriptionRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $updateAudienceGroupDescriptionRequest;
             }
@@ -2828,7 +2918,7 @@ class ManageAudienceApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);

--- a/src/clients/manage-audience/lib/Api/ManageAudienceBlobApi.php
+++ b/src/clients/manage-audience/lib/Api/ManageAudienceBlobApi.php
@@ -41,8 +41,8 @@ namespace LINE\Clients\ManageAudience\Api;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
@@ -189,14 +189,15 @@ class ManageAudienceBlobApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -274,17 +275,25 @@ class ManageAudienceBlobApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -367,7 +376,7 @@ class ManageAudienceBlobApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -477,14 +486,15 @@ class ManageAudienceBlobApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -613,17 +623,25 @@ class ManageAudienceBlobApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -712,7 +730,7 @@ class ManageAudienceBlobApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);

--- a/src/clients/manage-audience/lib/Api/ManageAudienceBlobApi.php
+++ b/src/clients/manage-audience/lib/Api/ManageAudienceBlobApi.php
@@ -41,8 +41,8 @@ namespace LINE\Clients\ManageAudience\Api;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
@@ -189,15 +189,15 @@ class ManageAudienceBlobApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -275,25 +275,27 @@ class ManageAudienceBlobApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -486,15 +488,15 @@ class ManageAudienceBlobApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -623,25 +625,27 @@ class ManageAudienceBlobApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );

--- a/src/clients/messaging-api/lib/Api/MessagingApiApi.php
+++ b/src/clients/messaging-api/lib/Api/MessagingApiApi.php
@@ -41,8 +41,8 @@ namespace LINE\Clients\MessagingApi\Api;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
@@ -374,14 +374,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -550,17 +551,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -613,7 +622,7 @@ class MessagingApiApi
         if (isset($broadcastRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($broadcastRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($broadcastRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $broadcastRequest;
             }
@@ -634,7 +643,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -698,14 +707,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -765,17 +775,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -828,7 +846,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -894,14 +912,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -987,17 +1006,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -1066,7 +1093,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1133,14 +1160,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1265,17 +1293,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -1316,7 +1352,7 @@ class MessagingApiApi
         if (isset($couponCreateRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($couponCreateRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($couponCreateRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $couponCreateRequest;
             }
@@ -1337,7 +1373,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1404,14 +1440,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1522,17 +1559,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -1579,7 +1624,7 @@ class MessagingApiApi
         if (isset($richMenuRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($richMenuRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($richMenuRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $richMenuRequest;
             }
@@ -1600,7 +1645,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1666,14 +1711,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1743,17 +1789,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -1800,7 +1854,7 @@ class MessagingApiApi
         if (isset($createRichMenuAliasRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($createRichMenuAliasRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($createRichMenuAliasRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $createRichMenuAliasRequest;
             }
@@ -1821,7 +1875,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1887,14 +1941,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1956,17 +2011,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -2035,7 +2098,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -2101,14 +2164,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -2178,17 +2242,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -2257,7 +2329,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -2326,14 +2398,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -2446,17 +2519,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -2531,7 +2612,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -2596,14 +2677,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -2712,17 +2794,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -2775,7 +2865,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -2840,14 +2930,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -2956,17 +3047,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -3019,7 +3118,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -3086,14 +3185,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -3232,17 +3332,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -3311,7 +3419,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -3376,14 +3484,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -3492,17 +3601,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -3555,7 +3672,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -3624,14 +3741,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -3744,17 +3862,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -3832,7 +3958,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -3899,14 +4025,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -4017,17 +4144,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -4096,7 +4231,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -4165,14 +4300,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -4285,17 +4421,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -4380,7 +4524,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -4449,14 +4593,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -4569,17 +4714,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -4659,7 +4812,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -4726,14 +4879,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -4844,17 +4998,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -4923,7 +5085,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -4994,14 +5156,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -5144,17 +5307,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -5251,7 +5422,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -5316,14 +5487,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -5446,17 +5618,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -5509,7 +5689,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -5576,14 +5756,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -5722,17 +5903,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -5801,7 +5990,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -5866,14 +6055,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -5982,17 +6172,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -6045,7 +6243,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -6110,14 +6308,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -6226,17 +6425,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -6289,7 +6496,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -6356,14 +6563,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -6474,17 +6682,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -6554,7 +6770,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -6621,14 +6837,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -6739,17 +6956,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -6819,7 +7044,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -6886,14 +7111,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -7004,17 +7230,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -7084,7 +7318,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -7151,14 +7385,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -7269,17 +7504,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -7349,7 +7592,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -7416,14 +7659,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -7534,17 +7778,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -7614,7 +7866,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -7681,14 +7933,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -7799,17 +8052,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -7882,7 +8143,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -7949,14 +8210,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -8067,17 +8329,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -8146,7 +8416,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -8213,14 +8483,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -8331,17 +8602,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -8410,7 +8689,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -8477,14 +8756,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -8595,17 +8875,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -8674,7 +8962,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -8739,14 +9027,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -8855,17 +9144,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -8918,7 +9215,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -8985,14 +9282,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -9103,17 +9401,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -9183,7 +9489,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -9250,14 +9556,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -9368,17 +9675,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -9447,7 +9762,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -9512,14 +9827,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -9628,17 +9944,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -9691,7 +10015,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -9758,14 +10082,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -9876,17 +10201,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -9955,7 +10288,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -10024,14 +10357,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -10144,17 +10478,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -10239,7 +10581,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -10308,14 +10650,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -10428,17 +10771,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -10518,7 +10869,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -10583,14 +10934,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -10699,17 +11051,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -10762,7 +11122,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -10829,14 +11189,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -10947,17 +11308,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -11026,7 +11395,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -11092,14 +11461,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -11177,17 +11547,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -11256,7 +11634,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -11322,14 +11700,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -11391,17 +11770,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -11470,7 +11857,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -11538,14 +11925,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -11609,17 +11997,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -11704,7 +12100,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -11770,14 +12166,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -11839,17 +12236,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -11896,7 +12301,7 @@ class MessagingApiApi
         if (isset($richMenuBulkLinkRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($richMenuBulkLinkRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($richMenuBulkLinkRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $richMenuBulkLinkRequest;
             }
@@ -11917,7 +12322,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -11988,14 +12393,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -12124,17 +12530,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -12226,7 +12640,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -12292,14 +12706,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -12361,17 +12776,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -12418,7 +12841,7 @@ class MessagingApiApi
         if (isset($markMessagesAsReadRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($markMessagesAsReadRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($markMessagesAsReadRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $markMessagesAsReadRequest;
             }
@@ -12439,7 +12862,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -12505,14 +12928,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -12582,17 +13006,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -12639,7 +13071,7 @@ class MessagingApiApi
         if (isset($markMessagesAsReadByTokenRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($markMessagesAsReadByTokenRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($markMessagesAsReadByTokenRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $markMessagesAsReadByTokenRequest;
             }
@@ -12660,7 +13092,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -12729,14 +13161,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -12905,17 +13338,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -12968,7 +13409,7 @@ class MessagingApiApi
         if (isset($multicastRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($multicastRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($multicastRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $multicastRequest;
             }
@@ -12989,7 +13430,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -13058,14 +13499,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -13234,17 +13676,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -13297,7 +13747,7 @@ class MessagingApiApi
         if (isset($narrowcastRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($narrowcastRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($narrowcastRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $narrowcastRequest;
             }
@@ -13318,7 +13768,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -13387,14 +13837,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -13563,17 +14014,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -13626,7 +14085,7 @@ class MessagingApiApi
         if (isset($pushMessageRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($pushMessageRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($pushMessageRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $pushMessageRequest;
             }
@@ -13647,7 +14106,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -13715,14 +14174,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -13794,17 +14254,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -13863,7 +14331,7 @@ class MessagingApiApi
         if (isset($pnpMessagesRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($pnpMessagesRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($pnpMessagesRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $pnpMessagesRequest;
             }
@@ -13884,7 +14352,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -13951,14 +14419,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -14097,17 +14566,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -14154,7 +14631,7 @@ class MessagingApiApi
         if (isset($replyMessageRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($replyMessageRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($replyMessageRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $replyMessageRequest;
             }
@@ -14175,7 +14652,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -14241,14 +14718,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -14310,17 +14788,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -14367,7 +14853,7 @@ class MessagingApiApi
         if (isset($richMenuBatchRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($richMenuBatchRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($richMenuBatchRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $richMenuBatchRequest;
             }
@@ -14388,7 +14874,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -14454,14 +14940,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -14523,17 +15010,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -14602,7 +15097,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -14668,14 +15163,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -14737,17 +15233,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -14794,7 +15298,7 @@ class MessagingApiApi
         if (isset($setWebhookEndpointRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($setWebhookEndpointRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($setWebhookEndpointRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $setWebhookEndpointRequest;
             }
@@ -14815,7 +15319,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -14882,14 +15386,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -15014,17 +15519,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -15071,7 +15584,7 @@ class MessagingApiApi
         if (isset($showLoadingAnimationRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($showLoadingAnimationRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($showLoadingAnimationRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $showLoadingAnimationRequest;
             }
@@ -15092,7 +15605,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -15159,14 +15672,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -15277,17 +15791,25 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -15328,7 +15850,7 @@ class MessagingApiApi
         if (isset($testWebhookEndpointRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($testWebhookEndpointRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($testWebhookEndpointRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $testWebhookEndpointRequest;
             }
@@ -15349,7 +15871,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -15415,14 +15937,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -15484,17 +16007,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -15563,7 +16094,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -15629,14 +16160,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -15698,17 +16230,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -15755,7 +16295,7 @@ class MessagingApiApi
         if (isset($richMenuBulkUnlinkRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($richMenuBulkUnlinkRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($richMenuBulkUnlinkRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $richMenuBulkUnlinkRequest;
             }
@@ -15776,7 +16316,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -15844,14 +16384,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -15923,17 +16464,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -15996,7 +16545,7 @@ class MessagingApiApi
         if (isset($updateRichMenuAliasRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($updateRichMenuAliasRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($updateRichMenuAliasRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $updateRichMenuAliasRequest;
             }
@@ -16017,7 +16566,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -16083,14 +16632,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -16152,17 +16702,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -16209,7 +16767,7 @@ class MessagingApiApi
         if (isset($validateMessageRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($validateMessageRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($validateMessageRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $validateMessageRequest;
             }
@@ -16230,7 +16788,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -16296,14 +16854,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -16365,17 +16924,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -16422,7 +16989,7 @@ class MessagingApiApi
         if (isset($validateMessageRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($validateMessageRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($validateMessageRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $validateMessageRequest;
             }
@@ -16443,7 +17010,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -16509,14 +17076,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -16578,17 +17146,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -16635,7 +17211,7 @@ class MessagingApiApi
         if (isset($validateMessageRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($validateMessageRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($validateMessageRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $validateMessageRequest;
             }
@@ -16656,7 +17232,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -16722,14 +17298,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -16791,17 +17368,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -16848,7 +17433,7 @@ class MessagingApiApi
         if (isset($validateMessageRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($validateMessageRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($validateMessageRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $validateMessageRequest;
             }
@@ -16869,7 +17454,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -16935,14 +17520,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -17004,17 +17590,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -17061,7 +17655,7 @@ class MessagingApiApi
         if (isset($validateMessageRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($validateMessageRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($validateMessageRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $validateMessageRequest;
             }
@@ -17082,7 +17676,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -17148,14 +17742,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -17217,17 +17812,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -17274,7 +17877,7 @@ class MessagingApiApi
         if (isset($richMenuBatchRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($richMenuBatchRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($richMenuBatchRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $richMenuBatchRequest;
             }
@@ -17295,7 +17898,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -17361,14 +17964,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -17430,17 +18034,25 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -17487,7 +18099,7 @@ class MessagingApiApi
         if (isset($richMenuRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($richMenuRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($richMenuRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $richMenuRequest;
             }
@@ -17508,7 +18120,7 @@ class MessagingApiApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);

--- a/src/clients/messaging-api/lib/Api/MessagingApiApi.php
+++ b/src/clients/messaging-api/lib/Api/MessagingApiApi.php
@@ -41,8 +41,8 @@ namespace LINE\Clients\MessagingApi\Api;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
@@ -374,15 +374,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -551,25 +551,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -707,15 +709,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -775,25 +777,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -912,15 +916,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1006,25 +1010,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -1160,15 +1166,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1293,25 +1299,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -1440,15 +1448,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1559,25 +1567,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -1711,15 +1721,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1789,25 +1799,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -1941,15 +1953,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -2011,25 +2023,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -2164,15 +2178,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -2242,25 +2256,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -2398,15 +2414,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -2519,25 +2535,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -2677,15 +2695,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -2794,25 +2812,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -2930,15 +2950,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -3047,25 +3067,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -3185,15 +3207,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -3332,25 +3354,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -3484,15 +3508,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -3601,25 +3625,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -3741,15 +3767,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -3862,25 +3888,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -4025,15 +4053,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -4144,25 +4172,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -4300,15 +4330,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -4421,25 +4451,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -4593,15 +4625,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -4714,25 +4746,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -4879,15 +4913,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -4998,25 +5032,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -5156,15 +5192,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -5307,25 +5343,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -5487,15 +5525,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -5618,25 +5656,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -5756,15 +5796,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -5903,25 +5943,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -6055,15 +6097,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -6172,25 +6214,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -6308,15 +6352,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -6425,25 +6469,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -6563,15 +6609,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -6682,25 +6728,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -6837,15 +6885,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -6956,25 +7004,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -7111,15 +7161,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -7230,25 +7280,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -7385,15 +7437,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -7504,25 +7556,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -7659,15 +7713,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -7778,25 +7832,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -7933,15 +7989,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -8052,25 +8108,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -8210,15 +8268,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -8329,25 +8387,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -8483,15 +8543,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -8602,25 +8662,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -8756,15 +8818,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -8875,25 +8937,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -9027,15 +9091,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -9144,25 +9208,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -9282,15 +9348,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -9401,25 +9467,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -9556,15 +9624,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -9675,25 +9743,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -9827,15 +9897,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -9944,25 +10014,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -10082,15 +10154,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -10201,25 +10273,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -10357,15 +10431,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -10478,25 +10552,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -10650,15 +10726,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -10771,25 +10847,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -10934,15 +11012,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -11051,25 +11129,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -11189,15 +11269,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -11308,25 +11388,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -11461,15 +11543,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -11547,25 +11629,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -11700,15 +11784,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -11770,25 +11854,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -11925,15 +12011,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -11997,25 +12083,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -12166,15 +12254,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -12236,25 +12324,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -12393,15 +12483,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -12530,25 +12620,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -12706,15 +12798,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -12776,25 +12868,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -12928,15 +13022,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -13006,25 +13100,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -13161,15 +13257,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -13338,25 +13434,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -13499,15 +13597,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -13676,25 +13774,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -13837,15 +13937,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -14014,25 +14114,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -14174,15 +14276,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -14254,25 +14356,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -14419,15 +14523,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -14566,25 +14670,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -14718,15 +14824,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -14788,25 +14894,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -14940,15 +15048,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -15010,25 +15118,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -15163,15 +15273,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -15233,25 +15343,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -15386,15 +15498,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -15519,25 +15631,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -15672,15 +15786,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -15791,25 +15905,27 @@ class MessagingApiApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -15937,15 +16053,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -16007,25 +16123,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -16160,15 +16278,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -16230,25 +16348,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -16384,15 +16504,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -16464,25 +16584,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -16632,15 +16754,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -16702,25 +16824,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -16854,15 +16978,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -16924,25 +17048,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -17076,15 +17202,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -17146,25 +17272,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -17298,15 +17426,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -17368,25 +17496,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -17520,15 +17650,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -17590,25 +17720,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -17742,15 +17874,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -17812,25 +17944,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -17964,15 +18098,15 @@ class MessagingApiApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -18034,25 +18168,27 @@ class MessagingApiApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );

--- a/src/clients/messaging-api/lib/Api/MessagingApiBlobApi.php
+++ b/src/clients/messaging-api/lib/Api/MessagingApiBlobApi.php
@@ -41,8 +41,8 @@ namespace LINE\Clients\MessagingApi\Api;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
@@ -195,14 +195,15 @@ class MessagingApiBlobApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -325,17 +326,25 @@ class MessagingApiBlobApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -410,7 +419,7 @@ class MessagingApiBlobApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -514,14 +523,15 @@ class MessagingApiBlobApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -644,17 +654,25 @@ class MessagingApiBlobApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -729,7 +747,7 @@ class MessagingApiBlobApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -833,14 +851,15 @@ class MessagingApiBlobApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -963,17 +982,25 @@ class MessagingApiBlobApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -1048,7 +1075,7 @@ class MessagingApiBlobApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1152,14 +1179,15 @@ class MessagingApiBlobApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1282,17 +1310,25 @@ class MessagingApiBlobApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -1367,7 +1403,7 @@ class MessagingApiBlobApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1472,14 +1508,15 @@ class MessagingApiBlobApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1555,17 +1592,25 @@ class MessagingApiBlobApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -1634,7 +1679,7 @@ class MessagingApiBlobApi
         if (isset($body)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($body));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($body), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $body;
             }
@@ -1655,7 +1700,7 @@ class MessagingApiBlobApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);

--- a/src/clients/messaging-api/lib/Api/MessagingApiBlobApi.php
+++ b/src/clients/messaging-api/lib/Api/MessagingApiBlobApi.php
@@ -41,8 +41,8 @@ namespace LINE\Clients\MessagingApi\Api;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
@@ -195,15 +195,15 @@ class MessagingApiBlobApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -326,25 +326,27 @@ class MessagingApiBlobApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -523,15 +525,15 @@ class MessagingApiBlobApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -654,25 +656,27 @@ class MessagingApiBlobApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -851,15 +855,15 @@ class MessagingApiBlobApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -982,25 +986,27 @@ class MessagingApiBlobApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -1179,15 +1185,15 @@ class MessagingApiBlobApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1310,25 +1316,27 @@ class MessagingApiBlobApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );
@@ -1508,15 +1516,15 @@ class MessagingApiBlobApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -1592,25 +1600,27 @@ class MessagingApiBlobApi
                     return [null, $response->getStatusCode(), $response->getHeaders()];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );

--- a/src/webhook/lib/Api/DummyApi.php
+++ b/src/webhook/lib/Api/DummyApi.php
@@ -41,8 +41,8 @@ namespace LINE\Webhook\Api;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
@@ -171,14 +171,15 @@ class DummyApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (RequestException $e) {
+            } catch (BadResponseException $e) {
+                $response = $e->getResponse();
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                    $response->getHeaders(),
+                    (string) $response->getBody()
                 );
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -289,17 +290,25 @@ class DummyApi
                     ];
                 },
                 function ($exception) {
-                    $response = $exception->getResponse();
-                    $statusCode = $response->getStatusCode();
-                    throw new ApiException(
-                        sprintf(
-                            '[%d] Error connecting to the API (%s)',
+                    if ($exception instanceof BadResponseException) {
+                        $response = $exception->getResponse();
+                        $statusCode = $response->getStatusCode();
+                        throw new ApiException(
+                            sprintf(
+                                '[%d] Error connecting to the API (%s)',
+                                $statusCode,
+                                $exception->getRequest()->getUri()
+                            ),
                             $statusCode,
-                            $exception->getRequest()->getUri()
-                        ),
-                        $statusCode,
-                        $response->getHeaders(),
-                        (string) $response->getBody()
+                            $response->getHeaders(),
+                            (string) $response->getBody()
+                        );
+                    }
+                    throw new ApiException(
+                        "[{$exception->getCode()}] {$exception->getMessage()}",
+                        (int) $exception->getCode(),
+                        null,
+                        null
                     );
                 }
             );
@@ -346,7 +355,7 @@ class DummyApi
         if (isset($callbackRequest)) {
             if (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the body
-                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($callbackRequest));
+                $httpBody = json_encode(ObjectSerializer::sanitizeForSerialization($callbackRequest), JSON_THROW_ON_ERROR);
             } else {
                 $httpBody = $callbackRequest;
             }
@@ -367,7 +376,7 @@ class DummyApi
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+                $httpBody = json_encode($formParams, JSON_THROW_ON_ERROR);
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);

--- a/src/webhook/lib/Api/DummyApi.php
+++ b/src/webhook/lib/Api/DummyApi.php
@@ -41,8 +41,8 @@ namespace LINE\Webhook\Api;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
@@ -171,15 +171,15 @@ class DummyApi
             $options = $this->createHttpClientOption();
             try {
                 $response = $this->client->send($request, $options);
-            } catch (BadResponseException $e) {
-                $response = $e->getResponse();
+            } catch (RequestException $e) {
+                $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $response ? $response->getHeaders() : null,
+                    $response ? (string) $response->getBody() : null
                 );
-            } catch (TransferException $e) {
+            } catch (ConnectException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     (int) $e->getCode(),
@@ -290,25 +290,27 @@ class DummyApi
                     ];
                 },
                 function ($exception) {
-                    if ($exception instanceof BadResponseException) {
-                        $response = $exception->getResponse();
-                        $statusCode = $response->getStatusCode();
+                    $response = $exception instanceof RequestException && method_exists($exception, 'getResponse')
+                        ? $exception->getResponse()
+                        : null;
+                    if ($response === null) {
                         throw new ApiException(
-                            sprintf(
-                                '[%d] Error connecting to the API (%s)',
-                                $statusCode,
-                                $exception->getRequest()->getUri()
-                            ),
-                            $statusCode,
-                            $response->getHeaders(),
-                            (string) $response->getBody()
+                            "[{$exception->getCode()}] {$exception->getMessage()}",
+                            (int) $exception->getCode(),
+                            null,
+                            null
                         );
                     }
+                    $statusCode = $response->getStatusCode();
                     throw new ApiException(
-                        "[{$exception->getCode()}] {$exception->getMessage()}",
-                        (int) $exception->getCode(),
-                        null,
-                        null
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
                     );
                 }
             );

--- a/test/clients/messaging-api/Api/MessagingApiApiGuzzleExceptionTest.php
+++ b/test/clients/messaging-api/Api/MessagingApiApiGuzzleExceptionTest.php
@@ -1,0 +1,202 @@
+<?php
+
+/**
+ * Copyright 2026 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace LINE\Tests\Clients\MessagingApi\Api;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TooManyRedirectsException;
+use GuzzleHttp\Promise\RejectedPromise;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use LINE\Clients\MessagingApi\Api\MessagingApiApi;
+use LINE\Clients\MessagingApi\ApiException;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies that Guzzle exceptions thrown by the HTTP client are converted
+ * into ApiException in the same way on both Guzzle 7 and Guzzle 8.
+ *
+ * All exceptions are constructed only with signatures that are compatible
+ * with both major versions:
+ * - On Guzzle 7 every RequestException has getResponse() (nullable).
+ * - On Guzzle 8 getResponse() exists only on ResponseException subclasses
+ *   (BadResponseException, TooManyRedirectsException), so the API code
+ *   guards the call with method_exists().
+ *
+ * See https://github.com/line/line-bot-sdk-php/pull/880
+ */
+class MessagingApiApiGuzzleExceptionTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    private const REQUEST_URI = 'https://api.line.me/v2/bot/followers/ids';
+
+    private function requestForException(): Request
+    {
+        return new Request('GET', self::REQUEST_URI);
+    }
+
+    private function apiThrowingOnSend(\Throwable $exception): MessagingApiApi
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('send')->once()->andThrow($exception);
+        return new MessagingApiApi($client);
+    }
+
+    private function apiRejectingOnSendAsync(\Throwable $exception): MessagingApiApi
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('sendAsync')->once()->andReturn(new RejectedPromise($exception));
+        return new MessagingApiApi($client);
+    }
+
+    public function testSyncCallConvertsBadResponseExceptionKeepingResponse(): void
+    {
+        $body = '{"message":"The request body has 1 error(s)"}';
+        $api = $this->apiThrowingOnSend(new BadResponseException(
+            'Client error',
+            $this->requestForException(),
+            new Response(400, ['x-line-request-id' => 'req-id'], $body),
+        ));
+
+        try {
+            $api->getFollowers();
+            $this->fail('ApiException was not thrown');
+        } catch (ApiException $e) {
+            $this->assertSame(400, $e->getCode());
+            $this->assertStringContainsString('[400]', $e->getMessage());
+            $this->assertSame(['req-id'], $e->getResponseHeaders()['x-line-request-id']);
+            $this->assertSame($body, $e->getResponseBody());
+        }
+    }
+
+    public function testSyncCallConvertsTooManyRedirectsExceptionKeepingResponse(): void
+    {
+        $api = $this->apiThrowingOnSend(new TooManyRedirectsException(
+            'Will not follow more than 5 redirects',
+            $this->requestForException(),
+            new Response(302, ['location' => 'https://example.com/'], ''),
+        ));
+
+        try {
+            $api->getFollowers();
+            $this->fail('ApiException was not thrown');
+        } catch (ApiException $e) {
+            $this->assertSame(302, $e->getCode());
+            $this->assertSame(['https://example.com/'], $e->getResponseHeaders()['location']);
+            $this->assertSame('', $e->getResponseBody());
+        }
+    }
+
+    public function testSyncCallConvertsRequestExceptionWithoutResponse(): void
+    {
+        $api = $this->apiThrowingOnSend(new RequestException(
+            'Error completing request',
+            $this->requestForException(),
+        ));
+
+        try {
+            $api->getFollowers();
+            $this->fail('ApiException was not thrown');
+        } catch (ApiException $e) {
+            $this->assertSame(0, $e->getCode());
+            $this->assertStringContainsString('Error completing request', $e->getMessage());
+            $this->assertNull($e->getResponseHeaders());
+            $this->assertNull($e->getResponseBody());
+        }
+    }
+
+    public function testSyncCallConvertsConnectException(): void
+    {
+        $api = $this->apiThrowingOnSend(new ConnectException(
+            'Connection refused',
+            $this->requestForException(),
+        ));
+
+        try {
+            $api->getFollowers();
+            $this->fail('ApiException was not thrown');
+        } catch (ApiException $e) {
+            $this->assertSame(0, $e->getCode());
+            $this->assertStringContainsString('Connection refused', $e->getMessage());
+            $this->assertNull($e->getResponseHeaders());
+            $this->assertNull($e->getResponseBody());
+        }
+    }
+
+    public function testAsyncCallConvertsBadResponseExceptionKeepingResponse(): void
+    {
+        $body = '{"message":"The request body has 1 error(s)"}';
+        $api = $this->apiRejectingOnSendAsync(new BadResponseException(
+            'Client error',
+            $this->requestForException(),
+            new Response(400, ['x-line-request-id' => 'req-id'], $body),
+        ));
+
+        try {
+            $api->getFollowersAsync()->wait();
+            $this->fail('ApiException was not thrown');
+        } catch (ApiException $e) {
+            $this->assertSame(400, $e->getCode());
+            $this->assertStringContainsString('Error connecting to the API', $e->getMessage());
+            $this->assertSame(['req-id'], $e->getResponseHeaders()['x-line-request-id']);
+            $this->assertSame($body, $e->getResponseBody());
+        }
+    }
+
+    public function testAsyncCallConvertsRequestExceptionWithoutResponse(): void
+    {
+        $api = $this->apiRejectingOnSendAsync(new RequestException(
+            'Error completing request',
+            $this->requestForException(),
+        ));
+
+        try {
+            $api->getFollowersAsync()->wait();
+            $this->fail('ApiException was not thrown');
+        } catch (ApiException $e) {
+            $this->assertSame(0, $e->getCode());
+            $this->assertStringContainsString('Error completing request', $e->getMessage());
+            $this->assertNull($e->getResponseHeaders());
+            $this->assertNull($e->getResponseBody());
+        }
+    }
+
+    public function testAsyncCallConvertsConnectException(): void
+    {
+        $api = $this->apiRejectingOnSendAsync(new ConnectException(
+            'Connection refused',
+            $this->requestForException(),
+        ));
+
+        try {
+            $api->getFollowersAsync()->wait();
+            $this->fail('ApiException was not thrown');
+        } catch (ApiException $e) {
+            $this->assertSame(0, $e->getCode());
+            $this->assertStringContainsString('Connection refused', $e->getMessage());
+            $this->assertNull($e->getResponseHeaders());
+            $this->assertNull($e->getResponseBody());
+        }
+    }
+}


### PR DESCRIPTION
Supersedes #876 (`guzzlehttp/guzzle` to `v8`).

Its CI fails because `laravel/framework` (via dev dependency `orchestra/testbench`) still requires Guzzle `^7.8.2`, so pinning the root requirement to `^8.0` makes `composer install` unresolvable.

## Changes
- composer.json
  - Widen `guzzlehttp/guzzle` to `^7.3 || ^8.0` so consumers can use either major version, while dev dependencies (Laravel, still Guzzle 7 only) stay installable.
- `api.pebble` + regenerated clients
  - Fix two Guzzle 8 breaking changes ([upgrade guide](https://github.com/guzzle/guzzle/blob/8.0.0/UPGRADING.md)):
    - `Utils::jsonEncode()` was removed
      - Use `json_encode(..., JSON_THROW_ON_ERROR)`.
    - `RequestException::getResponse()` was removed
      - see https://github.com/line/line-bot-sdk-php/pull/880#discussion_r3662989262
 - Although essentially unrelated, updating the submodule (to avoid CI failures) 
  - https://github.com/line/line-openapi/pull/130